### PR TITLE
simplify grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,153 +25,37 @@
 
 module.exports = function (grunt) {
     "use strict";
-    
-    var resolve = require("path").resolve,
-        chmod = require("fs").chmodSync;
-    
+        
     grunt.initConfig({
-        "pkg" : grunt.file.readJSON("package.json"),
-        "platform" : process.platform === "darwin" ? "mac" : "win",
-        "directories" : {
-            "downloads" : "downloads/",
-            "bin" : "bin/"
-        },
+        pkg : grunt.file.readJSON("package.json"),
 
-        "jshint" : {
-            "options" : {
-                "jshintrc"   : ".jshintrc"
+        platform : process.platform === "darwin" ? "mac" : "win",
+
+        jshint : {
+            options : {
+                jshintrc : ".jshintrc"
             },
-            "all" : [
+            all : [
                 "*.js",
                 "package.json",
                 ".jshintrc",
                 "lib/**/*.js",
                 "lib/jsx/**/*.jsx",
             ]
-        },
-        
-        "clean" : {
-            "download" : ["<%= directories.downloads %>"],
-            "bin" : ["<%= directories.bin %>"]
-        },
-        
-        "imagemagick": {
-            "version" : "6.8.4-8",
-            "platform-urls" : {
-                "mac" : "https://s3-us-west-1.amazonaws.com/adobe-generator/" +
-                    "ImageMagick-<%= imagemagick.version %>-x64-apple-portable.tar.gz",
-                "win" : "https://s3-us-west-1.amazonaws.com/adobe-generator/" +
-                    "ImageMagick-<%= imagemagick.version %>-Q16-x86-windows.zip"
-            },
-            "url" : "<%= grunt.config('imagemagick.platform-urls.' + grunt.config('platform')) %>",
-            "archiveFilename" :
-                "<%= grunt.config('imagemagick.url').substr(grunt.config('imagemagick.url').lastIndexOf('/') + 1) %>",
-            "archivePath" : "<%= directories.downloads %><%= imagemagick.archiveFilename %>",
-            "extractedDirectory" : "ImageMagick-<%= imagemagick.version %>/",
-            "platform-executables" : {
-                "mac" : ["convert"],
-                "win" : ["convert.exe"]
-            },
-            "platform-executables-dir" : {
-                "mac" : "<%= directories.downloads %><%= imagemagick.extractedDirectory %>utilities/",
-                "win" : "<%= directories.downloads %><%= imagemagick.extractedDirectory %>"
-            }
-        },
-        "curl-dir": {
-            "imagemagick" : {
-                "src" : "<%= imagemagick.url %>",
-                "dest" : "<%= directories.downloads %>"
-            }
-        },
-        
-        "shell": {
-            "untarImagemagick" : {
-                "command": "tar -xvzf <%= imagemagick.archiveFilename %>",
-                "options": {
-                    "stdout": true,
-                    "stderr": true,
-                    "failOnError": true,
-                    "execOptions": {
-                        "cwd": "<%= directories.downloads %>"
-                    }
-                }
-            }
         }
-        
         
     });
 
     grunt.loadNpmTasks("grunt-contrib-jshint");
-    grunt.loadNpmTasks("grunt-contrib-copy");
-    grunt.loadNpmTasks("grunt-contrib-clean");
-    grunt.loadNpmTasks("grunt-shell");
-    grunt.loadNpmTasks("grunt-curl");
 
-    grunt.registerTask("default", ["jshint", "build"]);
+    grunt.registerTask("default", ["jshint"]);
         
-    grunt.registerTask("build", "Top-level configure and build", function () {
-        var platform = grunt.config("platform"),
-            binDir = grunt.config("directories.bin"),
-            executables = grunt.config("imagemagick.platform-executables")[platform];
-        
-        grunt.file.mkdir(binDir);
-        
-        var setupImagemagick = false;
-        executables.forEach(function (e) {
-            setupImagemagick = setupImagemagick || !grunt.file.exists(binDir, e);
-        });
-        
-        if (setupImagemagick) {
-            grunt.task.run("setup-imagemagick");
-        } else {
-            grunt.log.writeln("Imagemagick already set up");
+    grunt.registerTask(
+        "package",
+        "Create distributable package of plugin for distribution with Generator",
+        function () {
+            grunt.log.writeln("Not yet implemented");
         }
-        
-    });
-
-    
-    /* ImageMagick download tasks */
-    
-    grunt.registerTask("setup-imagemagick", ["download-imagemagick", "extract-imagemagick", "copy-imagemagick"]);
-        
-    grunt.registerTask("download-imagemagick", "Download ImageMagick", function () {
-        if (!grunt.file.exists(grunt.config("imagemagick.archivePath"))) {
-            grunt.log.writeln("Downloading ImageMagick");
-            grunt.task.run("curl-dir:imagemagick");
-        } else {
-            grunt.log.writeln("ImageMagick already downloaded");
-        }
-    });
-                       
-    grunt.registerTask("extract-imagemagick", "Extract ImageMagick", function () {
-        if (!grunt.file.exists(grunt.config("directories.downloads"), grunt.config("imagemagick.extractedDirectory"))) {
-            if (/\.tar\.gz$/.test(grunt.config("imagemagick.archiveFilename"))) {
-                grunt.task.run("shell:untarImagemagick");
-            } else if (/\.zip$/.test(grunt.config("imagemagick.archiveFilename"))) {
-                grunt.fail.warn("Extracting ZIPs not yet implemented");
-            } else {
-                grunt.fail.warn("No rule for extracting archive file");
-            }
-        } else {
-            grunt.log.writeln("ImageMagick already extracted");
-        }
-    });
-        
-    grunt.registerTask("copy-imagemagick", "Copy ImageMagick executables to bin", function () {
-        var platform = grunt.config("platform"),
-            binDir = grunt.config("directories.bin"),
-            executables = grunt.config("imagemagick.platform-executables")[platform],
-            executablesDir = grunt.config("imagemagick.platform-executables-dir")[platform];
-        
-        executables.forEach(function (e) {
-            grunt.file.copy(
-                resolve(executablesDir, e),
-                resolve(binDir, e)
-            );
-            if (platform === "mac") {
-                chmod(resolve(binDir, e), "755");
-            }
-        });
-    });
+    );
 
 };

--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
     "buffer-crc32": "~0.2.1"
   },
   "devDependencies": {
-    "grunt-shell": "~0.2.2",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-curl": "~0.5.0",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.5.4"
   }


### PR DESCRIPTION
Remove all binary downloading code from grunt since we're managing this in the PS build process now.

We should still implement a grunt task that makes a package of generator (with only the "production" npm modules) and its plugins. I've added a placeholder task for that called "package".
