### PR TITLE
Add menu registration and stubbing for actual event handling

### DIFF
--- a/lib/strings.json
+++ b/lib/strings.json
@@ -1,0 +1,18 @@
+{
+    "de_de": {
+        "ANOTHER_MENU_ID": "Another menu item",
+        "GENERATE_ASSETS": "Web Assets"
+    },
+    "ja_jp": {
+        "ANOTHER_MENU_ID": "購_Another menu item",
+        "GENERATE_ASSETS": "購_Web Assets"
+    },
+    "en_us": {
+        "ANOTHER_MENU_ID": "Another menu item",
+        "GENERATE_ASSETS": "Web Assets"
+    },
+    "fr_fr": {
+        "ANOTHER_MENU_ID": "Another menu item",
+        "GENERATE_ASSETS": "Web Assets"
+    }
+}


### PR DESCRIPTION
Simply creates a "Web Assets" menu that is toggleable. The menu doesn't actually affect any change in the asset generation process.

My suggestion:
1. quick review
2. merge so we can point others to this code as a way to create menus and listen for events
3. implement actual functionality of menu
