### PR TITLE
Adding units to absolute scaling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,7 @@ module.exports = function (grunt) {
                 ".jshintrc",
                 "lib/**/*.js",
                 "lib/jsx/**/*.jsx",
+                "test/**/*.js"
             ]
         },
  

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -1,0 +1,41 @@
+(function () {
+    "use strict";
+
+    var assert = require("nodeunit").assert;
+
+    assert.callsMatchSpecification = function (test, callback, spec) {
+        Object.keys(spec).forEach(function (argument) {
+            var actual   = JSON.stringify(callback(argument)),
+                expected = JSON.stringify(spec[argument]);
+            
+            test.equal(actual, expected, "Analysis of " + argument);
+        });
+    };
+
+    assert.functionReportsErrors = function (test, callback, args, expectedErrors) {
+        var functionWasCalled = false;
+
+        // Create a copy to prevent side effects when modifying
+        expectedErrors = expectedErrors.concat();
+        
+        function reportError(actualError) {
+            if (functionWasCalled) {
+                assert.fail(actualError, null, "An error message was sent asynchronously");
+                return;
+            }
+
+            if (expectedErrors.length === 0) {
+                assert.fail(actualError, null, "An extra error message was sent");
+                return;
+            }
+            var expectedError = expectedErrors.shift();
+            test.equal(actualError, expectedError, "Incorrect error message");
+        }
+
+        // Call callback with the provided arguments + reportError
+        callback.apply(null, args.concat([reportError]));
+        functionWasCalled = true;
+        
+        test.deepEqual(expectedErrors, [], expectedErrors.length + " errors were not reported");
+    };
+}());

--- a/test/test-analyze-component.js
+++ b/test/test-analyze-component.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    require("./assertions");
+
+    var analyzeComponent = require("../main")._analyzeComponent;
+
+    exports.testOnlyCheckPresentValues = function (test) {
+        test.functionReportsErrors(test, analyzeComponent, [{}], []);
+
+        test.done();
+    };
+
+    exports.testScalingChecks = function (test) {
+        // Correct values
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ scale: 0.5 }], []);
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ width: 300, height: 200, widthUnit: "px", heightUnit: "in" }], []);
+
+        // Incorrect values
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ scale:  0 }], ["Cannot scale an image to 0%"]);
+        
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ width:  0 }], ["Cannot set an image width to 0"]);
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ height: 0 }], ["Cannot set an image height to 0"]);
+        
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ widthUnit: "foo" }], ["Unsupported image width unit \"foo\""]);
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ heightUnit: "bar" }], ["Unsupported image height unit \"bar\""]);
+
+        test.done();
+    };
+
+    exports.testFileExtensionChecks = function (test) {
+        // Correct values
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ extension: "jpg" }], []);
+        
+        // Incorrect values
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ extension: "foo" }], ["Unsupported file extension \"foo\""]);
+
+        test.done();
+    };
+
+    exports.testQualityChecks = function (test) {
+        // Correct values
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ extension: "jpg", quality: "5" }], []);
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ extension: "jpg", quality: "50%" }], []);
+        
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ extension: "webp", quality: "5" }], []);
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ extension: "webp", quality: "50%" }], []);
+        
+        test.functionReportsErrors(test, analyzeComponent,
+            [{ extension: "png", quality: "32" }], []);
+        
+        // Incorrect values
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "jpg", quality: "0" }],
+            ["Quality must be between 1 and 10 (is \"0\")"]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "jpg", quality: "11" }],
+            ["Quality must be between 1 and 10 (is \"11\")"]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "jpg", quality: "0%" }],
+            ["Quality must be between 1% and 100% (is \"0%\")"]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "jpg", quality: "101%" }],
+            ["Quality must be between 1% and 100% (is \"101%\")"]);
+        
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "webp", quality: "0" }],
+            ["Quality must be between 1 and 10 (is \"0\")"]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "webp", quality: "11" }],
+            ["Quality must be between 1 and 10 (is \"11\")"]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "webp", quality: "0%" }],
+            ["Quality must be between 1% and 100% (is \"0%\")"]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "webp", quality: "101%" }],
+            ["Quality must be between 1% and 100% (is \"101%\")"]);
+
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "png", quality: "13" }],
+            ["PNG quality must be 8, 24 or 32 (is \"13\")"]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "png", quality: "13%" }],
+            ["PNG quality must be 8, 24 or 32 (is \"13%\")"]);
+
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "gif", quality: "23" }],
+            ["There should not be a quality setting for files with the extension \"gif\""]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "gif", quality: "23%" }],
+            ["There should not be a quality setting for files with the extension \"gif\""]);
+
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "gif", quality: "23" }],
+            ["There should not be a quality setting for files with the extension \"gif\""]);
+        test.functionReportsErrors(test, analyzeComponent, [{ extension: "gif", quality: "23%" }],
+            ["There should not be a quality setting for files with the extension \"gif\""]);
+
+        test.done();
+    };
+ 
+}());

--- a/test/test-parse-layer-name.js
+++ b/test/test-parse-layer-name.js
@@ -24,6 +24,8 @@
 (function () {
     "use strict";
 
+    require("./assertions");
+    
     var main = require("../main.js");
 
     exports.testExtensions = function (test) {
@@ -35,14 +37,11 @@
             "Foo.JpG":                    [{ name: "Foo.JpG",      file: "Foo.JpG",  extension: "jpg" }],
             "Foo.JpEg":                   [{ name: "Foo.JpEg",     file: "Foo.JpEg", extension: "jpeg" }],
             "Foo.PnG":                    [{ name: "Foo.PnG",      file: "Foo.PnG",  extension: "png" }],
+            "Foo.WeBp":                   [{ name: "Foo.WeBp",     file: "Foo.WeBp", extension: "webp" }],
         };
-        test.expect(Object.keys(spec).length);
-        Object.keys(spec).forEach(function (layerName) {
-            var actual   = JSON.stringify(main.parseLayerName(layerName)),
-                expected = JSON.stringify(spec[layerName]);
-            
-            test.equal(actual, expected, "Extension parsing");
-        });
+
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
         test.done();
     };
 
@@ -62,13 +61,9 @@
             "foo.jpg-0%":         [{ name: "foo.jpg-0%",   file: "foo.jpg",  extension: "jpg", quality: "0%" }],
             "foo.jpg-101%":       [{ name: "foo.jpg-101%", file: "foo.jpg",  extension: "jpg", quality: "101%" }],
         };
-        test.expect(Object.keys(spec).length);
-        Object.keys(spec).forEach(function (layerName) {
-            var actual   = JSON.stringify(main.parseLayerName(layerName)),
-                expected = JSON.stringify(spec[layerName]);
-            
-            test.equal(actual, expected, "JPG quality parsing");
-        });
+        
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
         test.done();
     };
 
@@ -82,13 +77,31 @@
             // Bad example for a PNG with a quality parameter
             "foo.png-42":                 [{ name: "foo.png-42",   file: "foo.png",  extension: "png", quality: "42" }],
         };
-        test.expect(Object.keys(spec).length);
-        Object.keys(spec).forEach(function (layerName) {
-            var actual   = JSON.stringify(main.parseLayerName(layerName)),
-                expected = JSON.stringify(spec[layerName]);
+        
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
+        test.done();
+    };
+
+    exports.testWEBPQuality = function (test) {
+        var spec = {
+            // Good examples for WEBPs with a quality parameter
+            "foo.webp-1":          [{ name: "foo.webp-1",    file: "foo.webp",  extension: "webp", quality: "1" }],
+            "foo.webp4":           [{ name: "foo.webp4",     file: "foo.webp",  extension: "webp", quality: "4" }],
+            "foo.webp-10":         [{ name: "foo.webp-10",   file: "foo.webp",  extension: "webp", quality: "10" }],
+            "foo.webp-1%":         [{ name: "foo.webp-1%",   file: "foo.webp",  extension: "webp", quality: "1%" }],
+            "foo.webp42%":         [{ name: "foo.webp42%",   file: "foo.webp",  extension: "webp", quality: "42%" }],
+            "foo.webp-100%":       [{ name: "foo.webp-100%", file: "foo.webp",  extension: "webp", quality: "100%" }],
             
-            test.equal(actual, expected, "PNG quality parsing");
-        });
+            // Bad examples for WEBPs with a quality parameter
+            "foo.webp-0":          [{ name: "foo.webp-0",    file: "foo.webp",  extension: "webp", quality: "0" }],
+            "foo.webp-11":         [{ name: "foo.webp-11",   file: "foo.webp",  extension: "webp", quality: "11" }],
+            "foo.webp-0%":         [{ name: "foo.webp-0%",   file: "foo.webp",  extension: "webp", quality: "0%" }],
+            "foo.webp-101%":       [{ name: "foo.webp-101%", file: "foo.webp",  extension: "webp", quality: "101%" }],
+        };
+        
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
         test.done();
     };
 
@@ -105,13 +118,9 @@
             "05% foo.png":                [{ name: "05% foo.png",  file: "foo.png",  extension: "png", scale: 0.05}],
             "1%foo.png":                  [{ name: "1%foo.png",    file: "foo.png",  extension: "png", scale: 0.01 }],
         };
-        test.expect(Object.keys(spec).length);
-        Object.keys(spec).forEach(function (layerName) {
-            var actual   = JSON.stringify(main.parseLayerName(layerName)),
-                expected = JSON.stringify(spec[layerName]);
-            
-            test.equal(actual, expected, "Relative scaling parsing");
-        });
+        
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
         test.done();
     };
 
@@ -120,22 +129,22 @@
             // Good examples of absolute scaling
             "100x80 foo.png":
                 [{ name: "100x80 foo.png", file: "foo.png", extension: "png",
-                        width: 100, widthUnit: "px", height: 80, heightUnit: "px"}],
+                        width: 100, height: 80 }],
             // spaces between lengths
-            "80 x 100 foo.png":
-                [{ name: "80 x 100 foo.png", file: "foo.png", extension: "png",
-                        width: 80, widthUnit: "px", height: 100, heightUnit: "px"}],
+            "80 x 100px foo.png":
+                [{ name: "80 x 100px foo.png", file: "foo.png", extension: "png",
+                        width: 80, height: 100, heightUnit: "px" }],
             // mix of units and no units
             "4in x100  foo.png":
                 [{ name: "4in x100  foo.png", file: "foo.png", extension: "png",
-                        width: 4, widthUnit: "in", height: 100, heightUnit: "px"}],
+                        width: 4, widthUnit: "in", height: 100 }],
             // mix of units
             "90mm x120cm foo.png":
                 [{ name: "90mm x120cm foo.png", file: "foo.png", extension: "png",
                         width: 90, widthUnit: "mm", height: 120, heightUnit: "cm"}],
             // wild card
             "100x? foo.png":
-                [{ name: "100x? foo.png", file: "foo.png", extension: "png", width: 100, widthUnit: "px"}],
+                [{ name: "100x? foo.png", file: "foo.png", extension: "png", width: 100 }],
             // wild card mixed with units
             "?x60in foo.png":
                 [{ name: "?x60in foo.png", file: "foo.png", extension: "png", height: 60, heightUnit: "in"}],
@@ -147,7 +156,7 @@
             // mix of scaling
             "80x100 60% foo.png":
                 [{ name: "80x100 60% foo.png", file: "60% foo.png", extension: "png",
-                        width: 80, widthUnit: "px", height: 100, heightUnit: "px"}],
+                        width: 80, height: 100 }],
             // mix of scaling with relative first
             "50% 80x100 foo.png":
                 [{ name: "50% 80x100 foo.png", file: "80x100 foo.png", extension: "png", scale: 0.50 }],
@@ -157,16 +166,11 @@
             // invalid unit, will not fail, but analyze will throw errors
             "30nm x20 nano.png":
                 [{ name: "30nm x20 nano.png", file: "nano.png", extension: "png",
-                        width: 30, widthUnit: "nm", height: 20, heightUnit: "px"}],
-                
+                        width: 30, widthUnit: "nm", height: 20 }],
         };
-        test.expect(Object.keys(spec).length);
-        Object.keys(spec).forEach(function (layerName) {
-            var actual   = JSON.stringify(main.parseLayerName(layerName)),
-                expected = JSON.stringify(spec[layerName]);
-            
-            test.equal(actual, expected, "Absolute scaling parsing");
-        });
+
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
         test.done();
     };
 
@@ -186,13 +190,9 @@
             "Layer 1.png+Layer 2.jpg":    [layer1PNG, layer2JPG],
             "Layer 1.png  + Layer 2.jpg": [layer1PNG, layer2JPG],
         };
-        test.expect(Object.keys(spec).length);
-        Object.keys(spec).forEach(function (layerName) {
-            var actual   = JSON.stringify(main.parseLayerName(layerName)),
-                expected = JSON.stringify(spec[layerName]);
-            
-            test.equal(actual, expected, "Layer grouping");
-        });
+        
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
         test.done();
     };
 
@@ -203,19 +203,13 @@
                 { name: "100% Delicious" },
                 { name: "42%Layer 1.png24", file: "Layer 1.png", extension: "png", quality: "24", scale: 0.42 },
                 { name: "100x100 Layer.jpg-90%", file: "Layer.jpg", extension: "jpg", quality: "90%",
-                        width: 100, widthUnit: "px", height: 100, heightUnit: "px" },
+                        width: 100, height: 100 },
                 { name: "250% Foo Bar Baz.gif", file: "Foo Bar Baz.gif", extension: "gif", scale: 2.5 },
             ],
         };
-        test.expect(Object.keys(spec).length);
-        Object.keys(spec).forEach(function (layerName) {
-            var actual   = JSON.stringify(main.parseLayerName(layerName)),
-                expected = JSON.stringify(spec[layerName]);
-            
-            test.equal(actual, expected, "Mixed testing");
-        });
+        
+        test.expect(Object.keys(spec).length + 1);
+        test.callsMatchSpecification(test, main._parseLayerName, spec);
         test.done();
     };
-
- 
 }());


### PR DESCRIPTION
Now asset generator accepts in, cm, mm and px as optional (px default)
suffixes to the width/height values. Converts as necessary using image
resolution.
