### PR TITLE
Fix issue with SVG files not deleting

### DIFF
--- a/main.js
+++ b/main.js
@@ -956,6 +956,9 @@
                                layerFilename: layerContext.validFileComponents[foundSVG].file };
                 _generator.evaluateJSXFile("./jsx/layerSVG.jsx", params);
                 // TODO: We should verify results here.
+                var genPath = resolve(documentContext.assetGenerationDir,
+                                      layerContext.validFileComponents[foundSVG].file);
+                layerContext.generatedFiles[genPath] = true;
                 layerUpdatedDeferred.resolve();
             }
             else {


### PR DESCRIPTION
Update generatedFiles so svg files created by generator are removed when
no longer referenced.
