### PR TITLE
Use a translatable label for the menu entry

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,7 +32,9 @@
         convert = require("./lib/convert");
 
     var DELAY_TO_WAIT_UNTIL_USER_DONE = 300,
-        MENU_ID = "assets";
+        MENU_ID = "assets",
+        // This format allows localization by Photoshop
+        MENU_LABEL = "$$$/JavaScripts/Generate/Name=Web Assets";
 
     var DEFAULT_JPG_AND_WEBP_QUALITY = 90;
 
@@ -1062,7 +1064,7 @@
         // 4. Initiate asset generation on current document if enabled
         //
 
-        _generator.addMenuItem(MENU_ID, "Web Assets", true, false).then(
+        _generator.addMenuItem(MENU_ID, MENU_LABEL, true, false).then(
             function () {
                 _generator.publish("assets.info.menuCreated", MENU_ID);
             }, function () {


### PR DESCRIPTION
Requires adobe-photoshop/generator#56, otherwise labels will appear including the $$$ prefix.

-- Note below is outdated, but kept for context --
@timothynoel Please assign whoever you think should deal with this :)
