### PR TITLE
Reset the state before requesting the entire document

### DIFF
--- a/main.js
+++ b/main.js
@@ -421,6 +421,9 @@
                     }
                 }
                 // Act as if everything has changed
+                if (_contextPerDocument[documentId]) {
+                    resetDocumentContext(documentId);
+                }
                 processChangesToDocument(document);
             },
             function (err) {
@@ -447,6 +450,18 @@
         _generator.setDocumentSettingsForPlugin(settings, PLUGIN_ID).done();
     }
 
+    function resetDocumentContext(documentId) {
+        console.log("Resetting state for document" + documentId);
+        var context = _contextPerDocument[documentId];
+        if (!context) {
+            context = _contextPerDocument[documentId] = {
+                assetGenerationEnabled: false
+            };
+        }
+        context.document = { id: documentId };
+        context.layers   = {};
+    }
+
     function processChangesToDocument(document) {
         // Stop if the document isn't an object describing a menu (could be "[ActionDescriptor]")
         // Happens if no document is open, but maybe also at other times
@@ -457,11 +472,8 @@
         var context = _contextPerDocument[document.id];
         
         if (!context) {
-            context = _contextPerDocument[document.id] = {
-                document: { id: document.id },
-                layers: {},
-                assetGenerationEnabled: false
-            };
+            resetDocumentContext(document.id);
+            context = _contextPerDocument[document.id];
             
             if (document.generatorSettings) {
                 console.log("Document contains generator settings", document.generatorSettings);


### PR DESCRIPTION
This allows an error in a layer name to contribute to the errors.txt even if the name was set before asset generation was enabled (only then we also generate errors.txt). It also better fits the idea of requestEntireDocument().

It seems a bit messy, though. I'm open to suggestions - we may want more refactoring anyway, and so could defer to such a time.
