### PR TITLE
disable webp support by default and add config option

### DIFF
--- a/main.js
+++ b/main.js
@@ -244,10 +244,14 @@
     
     function analyzeComponent(component, reportError) {
         var supportedUnits      = ["in", "cm", "px", "mm"];
-        var supportedExtensions = ["jpg", "jpeg", "png", "gif", "webp"];
+        var supportedExtensions = ["jpg", "jpeg", "png", "gif"];
 
         if (_config && _config["svg-enabled"]) {
             supportedExtensions.push("svg");
+        }
+
+        if (_config && _config["webp-enabled"]) {
+            supportedExtensions.push("webp");
         }
 
         // File name checks
@@ -1285,5 +1289,6 @@
     // Unit test function exports
     exports._parseLayerName   = parseLayerName;
     exports._analyzeComponent = analyzeComponent;
+    exports._setConfig = function (config) { _config = config; };
 
 }());

--- a/test/test-analyze-component.js
+++ b/test/test-analyze-component.js
@@ -26,7 +26,13 @@
 
     require("./assertions");
 
-    var analyzeComponent = require("../main")._analyzeComponent;
+    var main = require("../main");
+    main._setConfig({
+        "svg-enabled": true,
+        "webp-enabled": true
+    });
+
+    var analyzeComponent = main._analyzeComponent;
 
     exports.testOnlyCheckPresentValues = function (test) {
         test.functionReportsErrors(test, analyzeComponent, [{}], []);


### PR DESCRIPTION
Fixes #109 

This config file can be used to turn webp back on:

``` json
{
    "generator-assets":  { 
        "svg-enabled": false,
        "webp-enabled": true
    }
}
```

Name as `generator.json` in CWD.

Also documented this config option in https://github.com/adobe-photoshop/generator-assets/wiki/Configuration-Options
