### PR TITLE
store starting menu state at menu event, use to enable/disable

### DIFF
--- a/main.js
+++ b/main.js
@@ -491,8 +491,9 @@
             return;
         }
         
-        console.log("Menu event", stringify(event));
-        _documentIdsWithMenuClicks[_currentDocumentId || ""] = true;
+        var startingMenuState = _generator.getMenuState(menu.name);
+        console.log("Menu event %s, starting state %s", stringify(event), stringify(startingMenuState));
+        _documentIdsWithMenuClicks[_currentDocumentId || ""] = startingMenuState;
         
         // Before we know about the current document, we cannot reasonably process the events
         if (!_currentDocumentId || !_contextPerDocument[_currentDocumentId]) {
@@ -512,6 +513,8 @@
         var nowEnabledDocumentIds = [];
 
         clickedDocumentIds.forEach(function (originalDocumentId) {
+            var startingMenuState = _documentIdsWithMenuClicks[originalDocumentId];
+
             if (!originalDocumentId) {
                 console.log("Interpreting menu event for unknown document" +
                     " as being for the current one (" + _currentDocumentId + ")");
@@ -534,11 +537,11 @@
             delete _documentIdsWithMenuClicks[originalDocumentId];
 
             // Toggle the state
-            context.assetGenerationEnabled = !context.assetGenerationEnabled;
+            context.assetGenerationEnabled = !(startingMenuState && startingMenuState.checked);
             if (context.assetGenerationEnabled) {
                 nowEnabledDocumentIds.push(documentId);
             }
-            
+
             console.log("Asset generation is now " +
                 (context.assetGenerationEnabled ? "enabled" : "disabled") + " for document ID " + documentId);
         });


### PR DESCRIPTION
Fixes #108 

Requires adobe-photoshop/generator#98

This is slightly harder to test now, because the "Generate" menu is always disabled once the user has explicitly disabled Geneartor. So, you have to get back to the "first launch" state.

**Here are the new repro steps:**
1. Create a file which has metadata set for asset generation to be enabled
2. Quit Photoshop
3. Relaunch Photoshop, trashing preferences
4. Open file from step 1
5. Enable Generator by choosing the dummy "Generate > Web Assets" menu

**New correct behavior (after this PR):**

Generator launches, asset generation is enabled for the document

**Old broken behavior (before this PR):**

Generator launches, observes that the document already has asset generation enabled, and toggles it to off because the menu was chosen.
