### PR TITLE
Integrate new SVG code

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
-  "generator-core-version": "~1",
+  "generator-core-version": "~2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe-photoshop/generator-assets"


### PR DESCRIPTION
This version has all code in GitHub, and uses the KVLR I/O to write out data.  Also includes in-line image data generation.  Note you must setup the config file in order to use SVG.
Fixes #82 
Fixes #81 
