### PR TITLE
iOS and Android asset generation options (for discussion)

### DIFF
--- a/lib/componentmanager.js
+++ b/lib/componentmanager.js
@@ -125,6 +125,13 @@
             }
         }
 
+        if (def.hasOwnProperty("tags")) {
+            derived.tags || (derived.tags = {});
+            for (var k in def.tags) if (def.tags.hasOwnProperty(k)) {
+                derived.tags[k] = def.tags[k];
+            }
+        }
+
         derived.id = def.id + ":" + basic.id;
         derived.assetPath = _getAssetPath(derived);
         derived.default = def;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -53,9 +53,9 @@ module.exports = (function() {
         peg$c11 = { type: "other", description: "A single default specification component" },
         peg$c12 = [],
         peg$c13 = null,
-        peg$c14 = function(size, folders, suffix) { return size || folders.length > 0 || (suffix && suffix.trim().length > 0)},
+        peg$c14 = function(tags, size, folders, suffix) { return size || folders.length > 0 || (suffix && suffix.trim().length > 0)},
         peg$c15 = void 0,
-        peg$c16 = function(size, folders, suffix) { // require at least one spec
+        peg$c16 = function(tags, size, folders, suffix) { // require at least one spec
                 var result = {
                     "default": true,
                     name: text().trim()
@@ -73,6 +73,10 @@ module.exports = (function() {
                 }
 
                 mergeSize(size, result);
+
+                if (tags) {
+                    result.tags = tags;
+                }
 
                 return result;
             },
@@ -156,22 +160,140 @@ module.exports = (function() {
         peg$c41 = function(param, ext) {
                 return param.join("") + (ext || "");
             },
-        peg$c42 = { type: "other", description: "Relative or absolute scale" },
-        peg$c43 = " ",
-        peg$c44 = { type: "literal", value: " ", description: "\" \"" },
-        peg$c45 = function(abs) {
+        peg$c42 = { type: "other", description: "List of tags" },
+        peg$c43 = function(first, rest) {
+                if (!rest.hasOwnProperty(first.name))
+                    rest[first.name] = first
+                return rest;
+            },
+        peg$c44 = function(only) {
+                var result = {};
+                result[only.name] = only
+                return result;
+            },
+        peg$c45 = { type: "other", description: "A single tag, including the value if any" },
+        peg$c46 = "#padto",
+        peg$c47 = { type: "literal", value: "#padto", description: "\"#padto\"" },
+        peg$c48 = function(size, alignment) {
+                return {
+                    name: "padto",
+                    size: size,
+                    alignment: alignment || {}
+                }
+            },
+        peg$c49 = "#padmul",
+        peg$c50 = { type: "literal", value: "#padmul", description: "\"#padmul\"" },
+        peg$c51 = function(divisors, alignment) {
+                return {
+                    name: "padmul",
+                    divisors: divisors,
+                    alignment: alignment || {}
+                }
+            },
+        peg$c52 = "#pad",
+        peg$c53 = { type: "literal", value: "#pad", description: "\"#pad\"" },
+        peg$c54 = function(padding) {
+                return {
+                    name: "pad",
+                    padding: padding
+                }
+            },
+        peg$c55 = "#",
+        peg$c56 = { type: "literal", value: "#", description: "\"#\"" },
+        peg$c57 = function(name) {
+                error("unsupported tag " + name);
+            },
+        peg$c58 = { type: "other", description: "Required start of a tag's value" },
+        peg$c59 = "(",
+        peg$c60 = { type: "literal", value: "(", description: "\"(\"" },
+        peg$c61 = function() { expected("value of the tag in parens") },
+        peg$c62 = { type: "other", description: "Required end of a tag's value" },
+        peg$c63 = ")",
+        peg$c64 = { type: "literal", value: ")", description: "\")\"" },
+        peg$c65 = function() { expected(")") },
+        peg$c66 = { type: "other", description: "List of 1 or 2 numbers (vertical, horizontal), separated by commas or whitespace" },
+        peg$c67 = function(w, h) {
+                return [w, h];
+            },
+        peg$c68 = function(only) {
+                return [only, only]
+            },
+        peg$c69 = function() { expected("1 or 2 numbers (vertical, horizontal), separated by commas or whitespace") },
+        peg$c70 = { type: "other", description: "List 1 to 4 numbers, separated by commas or spaces" },
+        peg$c71 = function(top, right, bottom, left) {
+                return { top: top, right: right, bottom: bottom, left: left };
+            },
+        peg$c72 = function(top, horiz, bottom) {
+                return { top: top, right: horiz, bottom: bottom, left: horiz };
+            },
+        peg$c73 = function(vert, horiz) {
+                return { top: vert, right: horiz, bottom: vert, left: horiz };
+            },
+        peg$c74 = function(only) {
+                return { top: only, right: only, bottom: only, left: only };
+            },
+        peg$c75 = function() { expected("1 to 4 numbers (top, right, bottom, left), separated by commas or whitespace") },
+        peg$c76 = { type: "other", description: "Comma separator" },
+        peg$c77 = ",",
+        peg$c78 = { type: "literal", value: ",", description: "\",\"" },
+        peg$c79 = { type: "other", description: "Horizontal alignment" },
+        peg$c80 = "L",
+        peg$c81 = { type: "literal", value: "L", description: "\"L\"" },
+        peg$c82 = "left",
+        peg$c83 = { type: "literal", value: "left", description: "\"left\"" },
+        peg$c84 = function() { return 'left' },
+        peg$c85 = "R",
+        peg$c86 = { type: "literal", value: "R", description: "\"R\"" },
+        peg$c87 = "right",
+        peg$c88 = { type: "literal", value: "right", description: "\"right\"" },
+        peg$c89 = function() { return 'right' },
+        peg$c90 = "C",
+        peg$c91 = { type: "literal", value: "C", description: "\"C\"" },
+        peg$c92 = "center",
+        peg$c93 = { type: "literal", value: "center", description: "\"center\"" },
+        peg$c94 = function() { return 'center' },
+        peg$c95 = { type: "other", description: "Vertical alignment" },
+        peg$c96 = "T",
+        peg$c97 = { type: "literal", value: "T", description: "\"T\"" },
+        peg$c98 = "top",
+        peg$c99 = { type: "literal", value: "top", description: "\"top\"" },
+        peg$c100 = function() { return 'top' },
+        peg$c101 = "M",
+        peg$c102 = { type: "literal", value: "M", description: "\"M\"" },
+        peg$c103 = "middle",
+        peg$c104 = { type: "literal", value: "middle", description: "\"middle\"" },
+        peg$c105 = function() { return 'middle' },
+        peg$c106 = { type: "other", description: "Horizontal and vertical alignment" },
+        peg$c107 = function(h, v) { return { horiz: h, vert: v } },
+        peg$c108 = function(v, h) { return { horiz: h, vert: v } },
+        peg$c109 = function(h) { return { horiz: h, vert: null } },
+        peg$c110 = function(v) { return { horiz: null, vert: v } },
+        peg$c111 = { type: "other", description: "Horizontal and vertical alignment, prefixed by a colon, a comma or whitespace" },
+        peg$c112 = function(value) {
+                return value;
+            },
+        peg$c113 = { type: "other", description: "Tag value" },
+        peg$c114 = /^[^)]/,
+        peg$c115 = { type: "class", value: "[^)]", description: "[^)]" },
+        peg$c116 = function(chars) {
+                return chars.join("")
+            },
+        peg$c117 = { type: "other", description: "Relative or absolute scale" },
+        peg$c118 = " ",
+        peg$c119 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c120 = function(abs) {
                 return abs;
             },
-        peg$c46 = { type: "other", description: "Relative scale, like 0.3" },
-        peg$c47 = function(scale) {
+        peg$c121 = { type: "other", description: "Relative scale, like 0.3" },
+        peg$c122 = function(scale) {
                 return {
                     scale: scale
                 };
             },
-        peg$c48 = { type: "other", description: "Absolute scale, like 50x100cm" },
-        peg$c49 = "x",
-        peg$c50 = { type: "literal", value: "x", description: "\"x\"" },
-        peg$c51 = function(width, height) {
+        peg$c123 = { type: "other", description: "Absolute scale, like 50x100cm" },
+        peg$c124 = "x",
+        peg$c125 = { type: "literal", value: "x", description: "\"x\"" },
+        peg$c126 = function(width, height) {
                 var result = {};
 
                 if (width.hasOwnProperty("value")) {
@@ -192,8 +314,8 @@ module.exports = (function() {
 
                 return result;
             },
-        peg$c52 = { type: "other", description: "Absolute scale component, like 100cm" },
-        peg$c53 = function(value, unit) {
+        peg$c127 = { type: "other", description: "Absolute scale component, like 100cm" },
+        peg$c128 = function(value, unit) {
                 var result = {
                     value: value,
                 };
@@ -204,52 +326,53 @@ module.exports = (function() {
 
                 return result;
             },
-        peg$c54 = "?",
-        peg$c55 = { type: "literal", value: "?", description: "\"?\"" },
-        peg$c56 = function() { // wildcard component
+        peg$c129 = "?",
+        peg$c130 = { type: "literal", value: "?", description: "\"?\"" },
+        peg$c131 = function() { // wildcard component
                 return {
                     // no unit
                 };
             },
-        peg$c57 = { type: "other", description: "Unit abbreviation" },
-        peg$c58 = /^[a-z]/i,
-        peg$c59 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
-        peg$c60 = function(first, second) {
+        peg$c132 = { type: "other", description: "Unit abbreviation" },
+        peg$c133 = /^[a-z]/i,
+        peg$c134 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
+        peg$c135 = function(first, second) {
                 return first + second;
             },
-        peg$c61 = { type: "other", description: "A percentage, like 30%" },
-        peg$c62 = function(num) {
+        peg$c136 = { type: "other", description: "A percentage, like 30%" },
+        peg$c137 = function(num) {
                 return num / 100;
             },
-        peg$c63 = function(chars) {
-                return chars.join("")
-            },
-        peg$c64 = { type: "other", description: "A good character or a dot" },
-        peg$c65 = ".",
-        peg$c66 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c67 = { type: "other", description: "A sequence of characters that ends with a dot" },
-        peg$c68 = function(chars) {
+        peg$c138 = { type: "other", description: "A sequence of laten letters and digits" },
+        peg$c139 = { type: "other", description: "Latin letter or digit" },
+        peg$c140 = /^[a-zA-Z0-9]/,
+        peg$c141 = { type: "class", value: "[a-zA-Z0-9]", description: "[a-zA-Z0-9]" },
+        peg$c142 = { type: "other", description: "A good character or a dot" },
+        peg$c143 = ".",
+        peg$c144 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c145 = { type: "other", description: "A sequence of characters that ends with a dot" },
+        peg$c146 = function(chars) {
                 return chars.concat(".");
             },
-        peg$c69 = { type: "other", description: "A sequence of characters, including dots" },
-        peg$c70 = function(chars) {
+        peg$c147 = { type: "other", description: "A sequence of characters, including dots" },
+        peg$c148 = function(chars) {
                 return chars.join("");
             },
-        peg$c71 = { type: "other", description: "A sequence of characters, excluding dots" },
-        peg$c72 = { type: "other", description: "A character, including dots" },
-        peg$c73 = /^[^,+]/,
-        peg$c74 = { type: "class", value: "[^,+]", description: "[^,+]" },
-        peg$c75 = { type: "other", description: "A character, excluding dots and other weird things" },
-        peg$c76 = /^[^+,.\/\0-\x1F]/,
-        peg$c77 = { type: "class", value: "[^+,.\\/\\0-\\x1F]", description: "[^+,.\\/\\0-\\x1F]" },
-        peg$c78 = { type: "other", description: "A nonnegative number, which may or may not have leading zeros" },
-        peg$c79 = function(parts) { return parseFloat(parts); },
-        peg$c80 = function(parts) { return parseFloat("0" + parts); },
-        peg$c81 = /^[0-9]/,
-        peg$c82 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c83 = { type: "other", description: "whitespace" },
-        peg$c84 = /^[ \t\n\r]/,
-        peg$c85 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c149 = { type: "other", description: "A sequence of characters, excluding dots" },
+        peg$c150 = { type: "other", description: "A character, including dots" },
+        peg$c151 = /^[^,+]/,
+        peg$c152 = { type: "class", value: "[^,+]", description: "[^,+]" },
+        peg$c153 = { type: "other", description: "A character, excluding dots and other weird things" },
+        peg$c154 = /^[^+,.\/\0-\x1F]/,
+        peg$c155 = { type: "class", value: "[^+,.\\/\\0-\\x1F]", description: "[^+,.\\/\\0-\\x1F]" },
+        peg$c156 = { type: "other", description: "A nonnegative number, which may or may not have leading zeros" },
+        peg$c157 = function(parts) { return parseFloat(parts); },
+        peg$c158 = function(parts) { return parseFloat("0" + parts); },
+        peg$c159 = /^[0-9]/,
+        peg$c160 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c161 = { type: "other", description: "whitespace" },
+        peg$c162 = /^[ \t\n\r]/,
+        peg$c163 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -259,7 +382,6 @@ module.exports = (function() {
         peg$maxFailExpected  = [],
         peg$silentFails      = 0,
 
-        peg$cache = {},
         peg$result;
 
     if ("startRule" in options) {
@@ -421,14 +543,6 @@ module.exports = (function() {
     function peg$parsestart() {
       var s0, s1;
 
-      var key    = peg$currPos * 29 + 0,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
       s0 = peg$parsedefaults();
       if (s0 === peg$FAILED) {
@@ -440,21 +554,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c0); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsedefaults() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 1,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -485,21 +589,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c1); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsedefaultspeclist() {
       var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 29 + 2,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -545,21 +639,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c6); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsedefaultspec() {
-      var s0, s1, s2, s3, s4, s5, s6, s7;
-
-      var key    = peg$currPos * 29 + 3,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
+      var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -574,38 +658,53 @@ module.exports = (function() {
         s1 = peg$c2;
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsescale();
+        s2 = peg$parsetaglist();
         if (s2 === peg$FAILED) {
           s2 = peg$c13;
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            s4 = [];
-            s5 = peg$parsefolder();
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$parsefolder();
+            s4 = peg$parsescale();
+            if (s4 === peg$FAILED) {
+              s4 = peg$c13;
             }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parsegoodcharsanddots();
-              if (s5 === peg$FAILED) {
-                s5 = peg$c13;
-              }
+              s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
-                s6 = peg$parse_();
+                s6 = [];
+                s7 = peg$parsefolder();
+                while (s7 !== peg$FAILED) {
+                  s6.push(s7);
+                  s7 = peg$parsefolder();
+                }
                 if (s6 !== peg$FAILED) {
-                  peg$reportedPos = peg$currPos;
-                  s7 = peg$c14(s2, s4, s5);
-                  if (s7) {
-                    s7 = peg$c15;
-                  } else {
-                    s7 = peg$c2;
+                  s7 = peg$parsegoodcharsanddots();
+                  if (s7 === peg$FAILED) {
+                    s7 = peg$c13;
                   }
                   if (s7 !== peg$FAILED) {
-                    peg$reportedPos = s0;
-                    s1 = peg$c16(s2, s4, s5);
-                    s0 = s1;
+                    s8 = peg$parse_();
+                    if (s8 !== peg$FAILED) {
+                      peg$reportedPos = peg$currPos;
+                      s9 = peg$c14(s2, s4, s6, s7);
+                      if (s9) {
+                        s9 = peg$c15;
+                      } else {
+                        s9 = peg$c2;
+                      }
+                      if (s9 !== peg$FAILED) {
+                        peg$reportedPos = s0;
+                        s1 = peg$c16(s2, s4, s6, s7);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$c2;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$c2;
+                    }
                   } else {
                     peg$currPos = s0;
                     s0 = peg$c2;
@@ -640,21 +739,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c11); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsespeclist() {
       var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 29 + 4,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -700,21 +789,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsespec() {
       var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 29 + 5,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$parsefilespec();
@@ -748,21 +827,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c19); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsefolder() {
       var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 29 + 6,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -805,21 +874,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsefilespec() {
       var s0, s1, s2, s3, s4, s5, s6;
-
-      var key    = peg$currPos * 29 + 7,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -876,21 +935,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c26); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsefilename() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 8,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -924,21 +973,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c28); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsefileext() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 9,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -987,21 +1026,11 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsequality() {
       var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 29 + 10,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -1059,21 +1088,845 @@ module.exports = (function() {
         if (peg$silentFails === 0) { peg$fail(peg$c34); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
+      return s0;
+    }
+
+    function peg$parsetaglist() {
+      var s0, s1, s2, s3;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = peg$parsetag();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parsewhitespace();
+        if (s3 !== peg$FAILED) {
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parsewhitespace();
+          }
+        } else {
+          s2 = peg$c2;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsetaglist();
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c43(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c2;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsetag();
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c44(s1);
+        }
+        s0 = s1;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c42); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsetag() {
+      var s0, s1, s2, s3, s4, s5;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 6) === peg$c46) {
+        s1 = peg$c46;
+        peg$currPos += 6;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsetagvalstart();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsetwonumbersreq();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parsesephvalign();
+            if (s4 === peg$FAILED) {
+              s4 = peg$c13;
+            }
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parsetagvalend();
+              if (s5 !== peg$FAILED) {
+                peg$reportedPos = s0;
+                s1 = peg$c48(s3, s4);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c2;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c2;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 7) === peg$c49) {
+          s1 = peg$c49;
+          peg$currPos += 7;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsetagvalstart();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parsetwonumbersreq();
+            if (s3 !== peg$FAILED) {
+              s4 = peg$parsesephvalign();
+              if (s4 === peg$FAILED) {
+                s4 = peg$c13;
+              }
+              if (s4 !== peg$FAILED) {
+                s5 = peg$parsetagvalend();
+                if (s5 !== peg$FAILED) {
+                  peg$reportedPos = s0;
+                  s1 = peg$c51(s3, s4);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$c2;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c2;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.substr(peg$currPos, 4) === peg$c52) {
+            s1 = peg$c52;
+            peg$currPos += 4;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsetagvalstart();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsefournumbersreq();
+              if (s3 !== peg$FAILED) {
+                s4 = peg$parsetagvalend();
+                if (s4 !== peg$FAILED) {
+                  peg$reportedPos = s0;
+                  s1 = peg$c54(s3);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$c2;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c2;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 35) {
+              s1 = peg$c55;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c56); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parsealphanumchars();
+              if (s2 !== peg$FAILED) {
+                peg$reportedPos = s0;
+                s1 = peg$c57(s2);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c2;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          }
+        }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c45); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsetagvalstart() {
+      var s0, s1;
+
+      peg$silentFails++;
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s0 = peg$c59;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = [];
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c61();
+        }
+        s0 = s1;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsetagvalend() {
+      var s0, s1;
+
+      peg$silentFails++;
+      if (input.charCodeAt(peg$currPos) === 41) {
+        s0 = peg$c63;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = [];
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c65();
+        }
+        s0 = s1;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsetwonumbers() {
+      var s0, s1, s2, s3;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = peg$parsenumber();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsecommasep();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsenumber();
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c67(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c2;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsenumber();
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c68(s1);
+        }
+        s0 = s1;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsetwonumbersreq() {
+      var s0, s1;
+
+      s0 = peg$parsetwonumbers();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = [];
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c69();
+        }
+        s0 = s1;
+      }
+
+      return s0;
+    }
+
+    function peg$parsefournumbers() {
+      var s0, s1, s2, s3, s4, s5, s6, s7;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = peg$parsenumber();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsecommasep();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsenumber();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parsecommasep();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parsenumber();
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parsecommasep();
+                if (s6 !== peg$FAILED) {
+                  s7 = peg$parsenumber();
+                  if (s7 !== peg$FAILED) {
+                    peg$reportedPos = s0;
+                    s1 = peg$c71(s1, s3, s5, s7);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$c2;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$c2;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c2;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c2;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsenumber();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsecommasep();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parsenumber();
+            if (s3 !== peg$FAILED) {
+              s4 = peg$parsecommasep();
+              if (s4 !== peg$FAILED) {
+                s5 = peg$parsenumber();
+                if (s5 !== peg$FAILED) {
+                  peg$reportedPos = s0;
+                  s1 = peg$c72(s1, s3, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$c2;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c2;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsenumber();
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsecommasep();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsenumber();
+              if (s3 !== peg$FAILED) {
+                peg$reportedPos = s0;
+                s1 = peg$c73(s1, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c2;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parsenumber();
+            if (s1 !== peg$FAILED) {
+              peg$reportedPos = s0;
+              s1 = peg$c74(s1);
+            }
+            s0 = s1;
+          }
+        }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsefournumbersreq() {
+      var s0, s1;
+
+      s0 = peg$parsefournumbers();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = [];
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c75();
+        }
+        s0 = s1;
+      }
+
+      return s0;
+    }
+
+    function peg$parsecommasep() {
+      var s0, s1;
+
+      peg$silentFails++;
+      if (input.charCodeAt(peg$currPos) === 44) {
+        s0 = peg$c77;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsehalign() {
+      var s0, s1;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 76) {
+        s1 = peg$c80;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 4) === peg$c82) {
+          s1 = peg$c82;
+          peg$currPos += 4;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
+        }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$reportedPos = s0;
+        s1 = peg$c84();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 82) {
+          s1 = peg$c85;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 5) === peg$c87) {
+            s1 = peg$c87;
+            peg$currPos += 5;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c88); }
+          }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c89();
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 67) {
+            s1 = peg$c90;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          }
+          if (s1 === peg$FAILED) {
+            if (input.substr(peg$currPos, 6) === peg$c92) {
+              s1 = peg$c92;
+              peg$currPos += 6;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c93); }
+            }
+          }
+          if (s1 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c94();
+          }
+          s0 = s1;
+        }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsevalign() {
+      var s0, s1;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 84) {
+        s1 = peg$c96;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 3) === peg$c98) {
+          s1 = peg$c98;
+          peg$currPos += 3;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$reportedPos = s0;
+        s1 = peg$c100();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 82) {
+          s1 = peg$c85;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 5) === peg$c87) {
+            s1 = peg$c87;
+            peg$currPos += 5;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c88); }
+          }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c89();
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 77) {
+            s1 = peg$c101;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          }
+          if (s1 === peg$FAILED) {
+            if (input.substr(peg$currPos, 6) === peg$c103) {
+              s1 = peg$c103;
+              peg$currPos += 6;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c104); }
+            }
+          }
+          if (s1 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c105();
+          }
+          s0 = s1;
+        }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c95); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsehvalign() {
+      var s0, s1, s2, s3;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = peg$parsehalign();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsevalign();
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c107(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c2;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsevalign();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parse_();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parsehalign();
+            if (s3 !== peg$FAILED) {
+              peg$reportedPos = s0;
+              s1 = peg$c108(s1, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c2;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsehalign();
+          if (s1 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c109(s1);
+          }
+          s0 = s1;
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parsevalign();
+            if (s1 !== peg$FAILED) {
+              peg$reportedPos = s0;
+              s1 = peg$c110(s1);
+            }
+            s0 = s1;
+          }
+        }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsesephvalign() {
+      var s0, s1, s2;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = peg$parsecommasep();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsehvalign();
+        if (s2 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c112(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c2;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsetagvalue() {
+      var s0, s1, s2, s3;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s1 = peg$c59;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        if (peg$c114.test(input.charAt(peg$currPos))) {
+          s3 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        }
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          if (peg$c114.test(input.charAt(peg$currPos))) {
+            s3 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          }
+        }
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 41) {
+            s3 = peg$c63;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c64); }
+          }
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c116(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c2;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c2;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c2;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+      }
 
       return s0;
     }
 
     function peg$parsescale() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 11,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$parserelscale();
@@ -1082,15 +1935,15 @@ module.exports = (function() {
         s1 = peg$parseabsscale();
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s2 = peg$c43;
+            s2 = peg$c118;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c119); }
           }
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c45(s1);
+            s1 = peg$c120(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1104,10 +1957,8 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c42); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1115,29 +1966,19 @@ module.exports = (function() {
     function peg$parserelscale() {
       var s0, s1;
 
-      var key    = peg$currPos * 29 + 12,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
       s0 = peg$currPos;
       s1 = peg$parsepercent();
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c47(s1);
+        s1 = peg$c122(s1);
       }
       s0 = s1;
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1145,26 +1986,18 @@ module.exports = (function() {
     function peg$parseabsscale() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 29 + 13,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
       s0 = peg$currPos;
       s1 = peg$parseabscomp();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c49) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c124) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c125); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
@@ -1172,7 +2005,7 @@ module.exports = (function() {
               s5 = peg$parseabscomp();
               if (s5 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c51(s1, s5);
+                s1 = peg$c126(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1197,24 +2030,14 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
     function peg$parseabscomp() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 14,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -1226,7 +2049,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c53(s1, s2);
+          s1 = peg$c128(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1239,25 +2062,23 @@ module.exports = (function() {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 63) {
-          s1 = peg$c54;
+          s1 = peg$c129;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c130); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c56();
+          s1 = peg$c131();
         }
         s0 = s1;
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c52); }
+        if (peg$silentFails === 0) { peg$fail(peg$c127); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1265,34 +2086,26 @@ module.exports = (function() {
     function peg$parseunit() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 29 + 15,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
       s0 = peg$currPos;
-      if (peg$c58.test(input.charAt(peg$currPos))) {
+      if (peg$c133.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c134); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c58.test(input.charAt(peg$currPos))) {
+        if (peg$c133.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+          if (peg$silentFails === 0) { peg$fail(peg$c134); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c60(s1, s2);
+          s1 = peg$c135(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1305,24 +2118,14 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
     function peg$parsepercent() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 16,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -1337,7 +2140,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c62(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1350,24 +2153,63 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c136); }
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
+      return s0;
+    }
+
+    function peg$parsealphanumchars() {
+      var s0, s1, s2;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = [];
+      s2 = peg$parsealphanumchar();
+      if (s2 !== peg$FAILED) {
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          s2 = peg$parsealphanumchar();
+        }
+      } else {
+        s1 = peg$c2;
+      }
+      if (s1 !== peg$FAILED) {
+        peg$reportedPos = s0;
+        s1 = peg$c116(s1);
+      }
+      s0 = s1;
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c138); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsealphanumchar() {
+      var s0, s1;
+
+      peg$silentFails++;
+      if (peg$c140.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c139); }
+      }
 
       return s0;
     }
 
     function peg$parsegoodcharsanddots() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 17,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       s0 = peg$currPos;
       s1 = [];
@@ -1382,11 +2224,9 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c63(s1);
+        s1 = peg$c116(s1);
       }
       s0 = s1;
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1394,32 +2234,22 @@ module.exports = (function() {
     function peg$parsegoodcharanddot() {
       var s0, s1;
 
-      var key    = peg$currPos * 29 + 18,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
       s0 = peg$parsegoodchar();
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s0 = peg$c65;
+          s0 = peg$c143;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1427,28 +2257,20 @@ module.exports = (function() {
     function peg$parsegoodcharsthendot() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 29 + 19,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
       s0 = peg$currPos;
       s1 = peg$parsegoodchars();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c65;
+          s2 = peg$c143;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c68(s1);
+          s1 = peg$c146(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1461,24 +2283,14 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c145); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
     function peg$parsechars() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 20,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -1494,30 +2306,20 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c70(s1);
+        s1 = peg$c148(s1);
       }
       s0 = s1;
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+        if (peg$silentFails === 0) { peg$fail(peg$c147); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
     function peg$parsegoodchars() {
       var s0, s1, s2;
-
-      var key    = peg$currPos * 29 + 21,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -1533,16 +2335,14 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c70(s1);
+        s1 = peg$c148(s1);
       }
       s0 = s1;
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1550,29 +2350,19 @@ module.exports = (function() {
     function peg$parsechar() {
       var s0, s1;
 
-      var key    = peg$currPos * 29 + 22,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
-      if (peg$c73.test(input.charAt(peg$currPos))) {
+      if (peg$c151.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c152); }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+        if (peg$silentFails === 0) { peg$fail(peg$c150); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1580,43 +2370,25 @@ module.exports = (function() {
     function peg$parsegoodchar() {
       var s0, s1;
 
-      var key    = peg$currPos * 29 + 23,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
       peg$silentFails++;
-      if (peg$c76.test(input.charAt(peg$currPos))) {
+      if (peg$c154.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c155); }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c75); }
+        if (peg$silentFails === 0) { peg$fail(peg$c153); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
     function peg$parsenumber() {
       var s0, s1, s2, s3, s4, s5, s6;
-
-      var key    = peg$currPos * 29 + 24,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = peg$currPos;
@@ -1626,11 +2398,11 @@ module.exports = (function() {
       if (s3 !== peg$FAILED) {
         s4 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s5 = peg$c65;
+          s5 = peg$c143;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parsedigits();
@@ -1665,7 +2437,7 @@ module.exports = (function() {
       s1 = s2;
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c79(s1);
+        s1 = peg$c157(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1673,11 +2445,11 @@ module.exports = (function() {
         s1 = peg$currPos;
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c65;
+          s3 = peg$c143;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parsedigits();
@@ -1698,31 +2470,21 @@ module.exports = (function() {
         s1 = s2;
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c80(s1);
+          s1 = peg$c158(s1);
         }
         s0 = s1;
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c156); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
     function peg$parsedigits() {
       var s0, s1;
-
-      var key    = peg$currPos * 29 + 25,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       s0 = [];
       s1 = peg$parsedigit();
@@ -1735,45 +2497,25 @@ module.exports = (function() {
         s0 = peg$c2;
       }
 
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
-
       return s0;
     }
 
     function peg$parsedigit() {
       var s0;
 
-      var key    = peg$currPos * 29 + 26,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
-      if (peg$c81.test(input.charAt(peg$currPos))) {
+      if (peg$c159.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c160); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
     function peg$parse_() {
       var s0, s1;
-
-      var key    = peg$currPos * 29 + 27,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
 
       peg$silentFails++;
       s0 = [];
@@ -1785,10 +2527,8 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c83); }
+        if (peg$silentFails === 0) { peg$fail(peg$c161); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
@@ -1796,23 +2536,13 @@ module.exports = (function() {
     function peg$parsewhitespace() {
       var s0;
 
-      var key    = peg$currPos * 29 + 28,
-          cached = peg$cache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-        return cached.result;
-      }
-
-      if (peg$c84.test(input.charAt(peg$currPos))) {
+      if (peg$c162.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c163); }
       }
-
-      peg$cache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -640,7 +640,7 @@
             
             var fnHandlePixmap = function (pixmap) {
                 var padding = pixmapSettings.hasOwnProperty("getPadding") ?
-                        pixmapSettings.getPadding(pixmap.width, pixmap.height) : undefined,
+                        pixmapSettings.getPadding(pixmap.width, pixmap.height) : {},
                     quality = component.quality,
                     format = component.extension,
                     ppi = this._document.resolution,
@@ -659,6 +659,8 @@
                     settings.lossless = this._webpLossless;
                 }
 
+                this._applyPadding(pixmap, padding, component);
+
                 return {
                     pixmap: pixmap,
                     settings: settings
@@ -676,6 +678,93 @@
         }.bind(this));
         
         return resultPromise;
+    };
+
+    PixmapRenderer.prototype._applyPadding = function (pixmap, padding, component) {
+        var tags = component.tags || {};
+
+        padding.left   || (padding.left    = 0);
+        padding.right  || (padding.right   = 0);
+        padding.top    || (padding.top     = 0);
+        padding.bottom || (padding.bottom  = 0);
+
+        if (tags.pad) {
+            padding.left   += tags.pad.padding.left;
+            padding.right  += tags.pad.padding.right;
+            padding.top    += tags.pad.padding.top;
+            padding.bottom += tags.pad.padding.bottom;
+        }
+
+        var extraPadding = { width: 0, height: 0 };
+        var extraPaddingAlignment = { horiz: 'center', vert: 'center' };
+
+        if (tags.padto) {
+            var extra = {
+                width:  tags.padto.size[0] - (pixmap.width  + padding.left + padding.right),
+                height: tags.padto.size[1] - (pixmap.height + padding.top  + padding.bottom)
+            };
+            if (extra.width > 0) {
+                extraPadding.width += extra.width;
+                if (tags.padto.alignment.horiz) {
+                    extraPaddingAlignment.horiz = tags.padto.alignment.horiz;
+                }
+            }
+            if (extra.height > 0) {
+                extraPadding.height += extra.height;
+                if (tags.padto.alignment.vert) {
+                    extraPaddingAlignment.vert  = tags.padto.alignment.vert;
+                }
+            }
+        }
+
+        var total, remainder, divisor;
+        if (tags.padmul && (divisor = tags.padmul.divisors[0]) > 1) {
+            total = pixmap.width + padding.left + padding.right + extraPadding.width;
+            remainder = total % divisor;
+            if (remainder > 0) {
+                extraPadding.width += (divisor - remainder);
+                if (tags.padmul.alignment.horiz) {
+                    extraPaddingAlignment.horiz = tags.padmul.alignment.horiz;
+                }
+            }
+        }
+        if (tags.padmul && (divisor = tags.padmul.divisors[1]) > 1) {
+            total = pixmap.height + padding.top + padding.bottom + extraPadding.height;
+            remainder = total % divisor;
+            if (remainder > 0) {
+                extraPadding.height += (divisor - remainder);
+                if (tags.padmul.alignment.vert) {
+                    extraPaddingAlignment.vert  = tags.padmul.alignment.vert;
+                }
+            }
+        }
+
+        // distribute the extra padding; TODO: add padAlign/padFrom option to specify the alignment
+        var firstAmount;
+        if (extraPadding.width > 0) {
+            if (extraPaddingAlignment.horiz === 'left') {
+                firstAmount = extraPadding.width;
+            } else if (extraPaddingAlignment.horiz === 'right') {
+                firstAmount = 0;
+            } else {
+                firstAmount = Math.floor(extraPadding.width / 2);
+            }
+            padding.left += firstAmount;
+            padding.right += extraPadding.width - firstAmount;
+        }
+        if (extraPadding.height > 0) {
+            if (extraPaddingAlignment.vert === 'top') {
+                firstAmount = extraPadding.height;
+            } else if (extraPaddingAlignment.vert === 'bottom') {
+                firstAmount = 0;
+            } else {
+                firstAmount = Math.floor(extraPadding.height / 2);
+            }
+            padding.top += firstAmount;
+            padding.bottom += extraPadding.height - firstAmount;
+        }
+
+        console.log('_applyPadding (%d, %d) with %j  ⇒  (%d, %d, %d, %d)', pixmap.width, pixmap.height, tags, padding.top, padding.right, padding.bottom, padding.left);
     };
 
     /**


### PR DESCRIPTION
Hey!

I've implemented a first take on iOS asset generation options. I'm an iOS/Android developer and plan to continue working on this and to active use it in everyday work. This pull request is meant to open the discussion about the way Adobe wants these features implemented, not for actual merging.

There's a bunch of stuff added here:
1. Ability to add arbitrary type-checked options at the end of a component spec, like `myfile.png iOS padTo=100x100`. The options and their types are declared at the start of the file, see TYPES and OPTIONS.
2. `pad` option that accepts a CSS-like list of dimensions and adds the specified top/right/bottom/left paddings, e.g. `pad=0:0:3:0`. The units are ignored for now, always assumed to be pixels.
3. `padTo` option that pads the image to the specified size, e.g. `padTo=64x64`.
4. `padToMultipleOf` option that pads the image so that it's a multiple of the specified size (this option can only be enabled via `iOS` option right now)
5. `iOS` option that actually turns the current component into two components, for 1x and 2x assets. So `image.png ios` is turned into an equivalent of `50% image.png, image@2x.png padToMultipleOf=2`, and `pad` and `padTo` values are also correctly scaled for the 1x asset.

I'm open to re-imagining and re-implementing these options in a way that can eventually be merged into the mainline. Until then, I'll be maintaining my fork. I realize it can be a long time, judging from other enhancement requests, and that the final syntax will probably look nothing like the current one.

I intend to add a similar option for Android resources in about a month (or maybe sooner) as well, and maybe other features based on my actual usage experience.

Known problems:
- test coverage is minimal (just a few parsing tests)
- pad, padTo ignore the units, always assume pixels — should either disallow units, or support any units
- the current design is assumed to be for Retina displays (2x, aka 320 dpi); this is adequate for iOS use cases, but some Android designs may be done at 3x now or in the future; we could use current document's ppi to determine this, although that probably will be an obstacle for most users; I'm yet to see a design PSD that isn't using the default 72 ppi value
