### PR TITLE
Add support for documentID while processing SVG

### DIFF
--- a/lib/layers.js
+++ b/lib/layers.js
@@ -213,11 +213,11 @@
             // SVGs use a different code path from the pixel-based formats
             if (component.extension === "svg") {
                 console.log("Creating SVG for layer " + layer.id + " (" + component.name + ")");
-                var svgPromise = utils.generator.getSVG(layer.id, component.scale || 1, document.id);
+                var svgPromise = utils.generator.getSVG(document.id, layer.id, {scale : component.scale || 1});
                 return svgPromise.then(
-                    function (svgJSON) {
-                        console.log("Received SVG text:\n" + decodeURI(svgJSON.svgText));
-                        return createLayerImage(decodeURI(svgJSON.svgText),
+                    function (svg) {
+                        console.log("Received SVG text:\n" + svg);
+                        return createLayerImage(svg,
                                                 component.folder,
                                                 component.file,
                                                 {format:  component.extension});


### PR DESCRIPTION
Fixes adobe-photoshop/generator-core#58  Note this requires PR adobe-photoshop/generator-core#158
