### PR TITLE
Disable "Image Assets" menu if no documents are open

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -62,11 +62,14 @@
             .then(function (enabled) {
                 var menuPromise = this._generator.addMenuItem(MENU_ID, MENU_LABEL, true, enabled);
 
-                // Start listening for menu and document change events
-                this._generator.onPhotoshopEvent("currentDocumentChanged",
-                    this._handleCurrentDocumentChanged.bind(this));
-                this._generator.onPhotoshopEvent("documentClosed",
-                    this._handleDocumentClosed.bind(this));
+                // Start listening for changes to the set of open documents
+                this._generator.onPhotoshopEvent("imageChanged", function (imageChangedEvent) {
+                    if (!!imageChangedEvent.closed) {
+                        this._updateOpenDocuments();
+                    } else if (!!imageChangedEvent.active) {
+                        this._handleCurrentDocumentChanged(imageChangedEvent.id);
+                    }
+                }.bind(this));
 
                 this._initialized = true;
                 return menuPromise;
@@ -157,6 +160,7 @@
             return enabled;
         }.bind(this)).fail(function (err) {
             this._logger.debug("Unable to initialize current document: ", err);
+            this._currentDocumentId = null;
             return false;
         }.bind(this));
     };
@@ -168,11 +172,14 @@
      */
     StateManager.prototype._updateOpenDocuments = function () {
         return this._generator.getOpenDocumentIDs().then(function (ids) {
+            if (ids.length === 0) {
+                this._setMenuState(null, false, false);
+            }
+
             var promises = ids.map(function (id) {
                 if (!this._activeDocumentIds.hasOwnProperty(id)) {
-                    return this._generator.getDocumentSettingsForPlugin(id, PLUGIN_ID).done(function (settings) {
+                    return this._generator.getDocumentSettingsForPlugin(id, PLUGIN_ID).then(function (settings) {
                         var enabled = !!(settings && settings.enabled);
-
                         this._setInternalState(id, enabled);
                     }.bind(this));
                 }
@@ -192,22 +199,9 @@
     StateManager.prototype._handleCurrentDocumentChanged = function (id) {
         this._currentDocumentId = id;
         
-        this._generator.getDocumentSettingsForPlugin(id, PLUGIN_ID).done(function (settings) {
-            var enabled = !!(settings && settings.enabled);
-
-            this._setMenuState(id, true, enabled);
-            this._setInternalState(id, enabled);
+        this._updateOpenDocuments().then(function () {
+            this._setMenuState(id, true, this._activeDocumentIds.hasOwnProperty(id));
         }.bind(this));
-
-        this._updateOpenDocuments();
-    };
-
-    StateManager.prototype._handleDocumentClosed = function (id) {
-        if (this._currentDocumentId === id) {
-            this._currentDocumentId = null;
-
-            this._setMenuState(null, false, false);
-        }
     };
 
     /**
@@ -282,7 +276,7 @@
                 } else {
                     // Something has gone wrong; reset _currentDocumentId and the menu state
                     this._initCurrentDocument().done(function (enabled) {
-                        this._setMenuState(this._currentDocumentId, true, enabled);
+                        this._setMenuState(this._currentDocumentId, this._currentDocumentId !== null, enabled);
                     }.bind(this));
                 }
             }


### PR DESCRIPTION
To accomplish this, switch from using `currentDocumentChanged` events to `imageChanged` events to see when the set of open documents changed. The logic now works as follows:

Whenever a document is closed, we call `_updateOpenDocuments`. Since documents can get closed "in the background" without the active document changing, this function does not change the menu state most of the time. (If a close necessitates a menu change, we will ALSO get an `imageChanged` activation event, which will update the menu.) However, if this function discovers there are now zero open documents, it sets `_currentDocumentId` to `null` and handles calling `_setMenuState` to disable the menu. 

Whenever a document gets activated (which could either be switching documents or opening a new document), we call `_handleCurrentDocumentChanged` (which perhaps could be renamed to `_handleDocumentActivation`). This method in turn calls `_updateOpenDocuments`, and then uses the results from that call to set the menu state appropriately.

Also, this PR (hopefully) clarifies some of the logic around `_updateOpenDocuments`.

And finally, it removes dead code for the nonexistent `documentClosed` event.
