### PR TITLE
_resetOpenDocumentIDs should always return a promise

### DIFF
--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -153,12 +153,12 @@
     DocumentManager.prototype._newClosedDocumentIds = null;
 
     /**
-     * Whether the set of currently open documents is being updated.
+     * If non-null, resolves once the set of open document IDs is finished updating
      *
      * @private
-     * @type {boolean}
+     * @type {?Promise}
      */
-    DocumentManager.prototype._openDocumentIdsUpdating = false;
+    DocumentManager.prototype._openDocumentIdsUpdatingPromise = null;
 
     /**
      * Whether the set of currently open documents needs to be updated.
@@ -305,17 +305,21 @@
     /**
      * Asynchronously reset the set of open document IDs.
      * 
+     * Only one instance of this method will execute at a time. Concurrent
+     * executions will result in the method running a second time after the
+     * first instance has finished.
+     * 
      * @private
+     * @return {!Promise} Resolves once the set of open document IDs has been
+     *      updated.
      */
     DocumentManager.prototype._resetOpenDocumentIDs = function () {
-        if (this._openDocumentIdsUpdating) {
+        if (this._openDocumentIdsUpdatingPromise) {
             this._openDocumentIdsStale = true;
-            return;
+            return this._openDocumentIdsUpdatingPromise;
         }
 
-        this._openDocumentIdsUpdating = true;
-
-        return this._generator.getOpenDocumentIDs()
+        var promise = this._generator.getOpenDocumentIDs()
             .then(function (ids) {
                 var originalIds = Object.keys(this._openDocumentIds);
 
@@ -336,13 +340,25 @@
                     }
                 }, this);
 
-                this._openDocumentIdsUpdating = false;
+                // In the case that there is an additional pending call to _resetOpenDocumentIDs,
+                // then we will re-call this function synchronously below. In order to
+                // not hit the early return, we need to clear the variable holding a reference to 
+                // the orignal promise. (Or, in the normal case, this is just cleaning up after
+                // ourselves.)
+                this._openDocumentIdsUpdatingPromise = null;
 
                 if (this._openDocumentIdsStale) {
                     this._openDocumentIdsStale = false;
-                    this._resetOpenDocumentIDs().done();
+
+                    // Returning a new promise in this "then" handler has the effect of not resolving
+                    // the original promise until we're done with the next update.
+                    return this._resetOpenDocumentIDs();
                 }
             }.bind(this));
+
+        this._openDocumentIdsUpdatingPromise = promise;
+
+        return promise;
     };
 
     /**


### PR DESCRIPTION
@timothynoel found that clicking `File > Share on Behance...` reliably crashed Node. The problem was that in the reentrant path through `DocumentManager._resetOpenDocumentIDs` no promise was returned, whereas the rest of the code assumed that this method would always return a promise. (We should probably rewrite all of this in TypeScript to prevent mistakes like this. Or get a better JavaScript programmer.)

Please test, review and merge into ps-next ASAP, @joelrbrandt :cocktail:  
