### PR TITLE
Add interpolation-type config parameter

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -179,9 +179,24 @@
      */
     function PixmapRenderer(generator, config, logger, document) {
         BaseRenderer.call(this, generator, config, logger, document);
+
+        if (config.hasOwnProperty("interpolation-type")) {
+            this._interpolationType = config["interpolation-type"];
+        }
     }
 
     util.inherits(PixmapRenderer, BaseRenderer);
+
+    /**
+     * Interpolation method to use when scaling pixmaps. If defined, this should
+     * take the value of one of the Generator.prototype.INTERPOLATION constants.
+     * Otherwise, Photoshop's default interpolation method is used.
+     * 
+     * @private
+     * @see Generator.prototype.getPixmap
+     * @type {boolean=}
+     */
+    PixmapRenderer.prototype._interpolationType = undefined;
 
     /**
      * Asynchronously get exact bounds for the given component. These bounds
@@ -319,6 +334,10 @@
                     // since they explicitly enabled it in Generator
                     pixmapSettings.useColorSettingsDither = false;
                 }
+            }
+            
+            if (this._interpolationType !== undefined) {
+                pixmapSettings.interpolationType = this._interpolationType;
             }
 
             return this._generator.getPixmap(this._document.id, layer.id, pixmapSettings).then(function (pixmap) {


### PR DESCRIPTION
Adds the `interpolation-type` config parameter, which controls the `interpolationType` property of the settings parameter to `Generator.prototype.getPixmap`. 

Addresses adobe-photoshop/generator-core#202.

@joelrbrandt: Please test and merge AFTER adobe-photoshop/generator-core#203.
