### PR TITLE
Support custom asset generation directory

### DIFF
--- a/lib/contexts.js
+++ b/lib/contexts.js
@@ -24,7 +24,8 @@
 (function () {
     "use strict";
 
-    var pathLib  = require("path"),
+    var utils = require("./utils"),
+        pathLib  = require("path"),
         resolve  = pathLib.resolve,
         extname  = pathLib.extname,
         basename = pathLib.basename,
@@ -53,8 +54,17 @@
             documentName = extension.length ? fileName.slice(0, -extension.length) : fileName,
             // For saved files, the directory the file was saved to. Otherwise, ~/Desktop
             baseDirectory = isSaved ? dirname(path) : _fallbackBaseDirectory,
-            // The directory to store generated assets in
-            assetGenerationDir = baseDirectory ? resolve(baseDirectory, documentName + "-assets") : null;
+            // The relative path of the directory to store generated assets in
+            relativeAssetGenerationDir;
+
+        if(utils.config && utils.config.hasOwnProperty("asset-generation-dir")) {
+            relativeAssetGenerationDir = utils.config["asset-generation-dir"];
+        } else {
+            relativeAssetGenerationDir = documentName + "-assets";
+        }
+
+        // The full path of the directory to store generated assets in
+        var assetGenerationDir = baseDirectory ? resolve(baseDirectory, relativeAssetGenerationDir) : null;
 
         context.path               = path;
         context.isSaved            = isSaved;


### PR DESCRIPTION
Allows users to specify an asset generation directory through `generator.js(on)`:

```json
{
  "generator-assets": {
    "asset-generation-dir": "/path/to/website/assets"
  }
}
```

Image asset generation is an awesome feature! This was the only thing missing for our team. Let me know if you don't want the patch or want to do it differently.