### PR TITLE
Reject space before filename with folders

### DIFF
--- a/etc/layernames.pegjs
+++ b/etc/layernames.pegjs
@@ -118,7 +118,7 @@ filename "Filename and quality suffix"
     = nameparts:goodcharsthendot+ suffix:fileext {
         var filename = String.prototype.concat.apply("", nameparts) + suffix.extension;
         if (filename.match(/^\s/)) {
-            error("Filename begins with whitespace", filename);
+            error("Filename begins with whitespace");
         }
 
         var result = {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -118,7 +118,7 @@ module.exports = (function() {
         peg$c29 = function(nameparts, suffix) {
                 var filename = String.prototype.concat.apply("", nameparts) + suffix.extension;
                 if (filename.match(/^\s/)) {
-                    error("Filename begins with whitespace", filename);
+                    error("Filename begins with whitespace");
                 }
 
                 var result = {

--- a/test/test-parse-layer-name.js
+++ b/test/test-parse-layer-name.js
@@ -36,7 +36,7 @@
      * 
      * @private
      * @param {string} layerName
-     * @returns {Array.<{name: string} | {file: string, extension: string}>}
+     * @returns {Array.<{name: string, file: string=, extension: string=} | {error: string}>} 
      */
     var _parseTest = function (layerName) {
         try {


### PR DESCRIPTION
@iwehrman - For issue #227 

If the layer filename is of format: [folder]/[whitespace][filename]…
parser throws an error, which gets logged to errors.txt.

Also update the unit tests so they call a unit test specific function
which catches the error thrown by parser so unit tests can check for
error messages. This needs to be refactored later to apply to all
parsing rules.
