### PR TITLE
Reset assets when the document bounds change

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -315,7 +315,7 @@
             this._fileManager.updateBasePath(this._document);
         }
 
-        if (change.resolution) {
+        if (change.resolution || change.bounds) {
             this._reset();
         }
 


### PR DESCRIPTION
Addresses [#3774405](https://watsonexp.corp.adobe.com/#bug=3774405).

This should go in for 15.0.1 if that's still possible.

CC @joelrbrandt 
