### PR TITLE
add config parameter use-psd-smart-object-pixel-scaling

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -66,6 +66,10 @@
         if (config.hasOwnProperty("allow-dither")) {
             this._allowDither = !!config["allow-dither"];
         }
+
+        if (config.hasOwnProperty("use-psd-smart-object-pixel-scaling")) {
+            this._forceSmartPSDPixelScaling = !!config["use-psd-smart-object-pixel-scaling"];
+        }
     }
 
     /**
@@ -82,6 +86,11 @@
      * @type {boolean=}
      */
     BaseRenderer.prototype._allowDither = undefined;
+
+    /**
+     * @type {boolean=}
+     */
+    BaseRenderer.prototype._forceSmartPSDPixelScaling = undefined;
 
     /**
      * Convert a value in a given unit, at particular resolution, to a value in pixels per inch.
@@ -340,6 +349,10 @@
             
             if (this._interpolationType !== undefined) {
                 pixmapSettings.interpolationType = this._interpolationType;
+            }
+
+            if (this._forceSmartPSDPixelScaling !== undefined) {
+                pixmapSettings.forceSmartPSDPixelScaling = this._forceSmartPSDPixelScaling;
             }
 
             return this._generator.getPixmap(this._document.id, layer.id, pixmapSettings).then(function (pixmap) {


### PR DESCRIPTION
In PS <= 15.0, PSD smart objects were always scaled in pixel space, which led to fuzzy vectors.

In PS >= 15.1, PSD smart objects will now be scaled in a vector-preserving way. Pull request adobe-photoshop/generator-core#224 adds an option to `getPixmap` to force old behavior.

This PR adds a config, called `use-psd-smart-object-pixel-scaling` option to force the old behavior in the assets plugin.

When this PR is merged, the config options wiki page should be updated: https://github.com/adobe-photoshop/generator-assets/wiki/Configuration-Options
