### PR TITLE
Force scaling to be a uniform transformation

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -298,6 +298,55 @@
     };
 
     /**
+     * Ensure that that pixmap will be scaled uniformly by updating the input and 
+     * output bounds to force Photoshop to perform a uniform transform. This is
+     * necessary to ensure that any effects are correctly scaled.
+     * 
+     * @private
+     * @param {{inputRect: object}, outputRect: object}} pixmapSettings
+     */
+    PixmapRenderer.prototype._ensureUniformTransform = function (pixmapSettings) {
+        var inputRect = pixmapSettings.inputRect,
+            outputRect = pixmapSettings.outputRect,
+            inputHeight = inputRect.bottom - inputRect.top,
+            inputWidth = inputRect.right - inputRect.left;
+
+        if (inputHeight > inputWidth) {
+            var outputWidth = outputRect.right - outputRect.left;
+
+            pixmapSettings.inputRect = {
+                top: inputRect.top,
+                right: inputRect.right,
+                bottom: inputRect.top + inputWidth,
+                left: inputRect.left
+            };
+
+            pixmapSettings.outputRect = {
+                top: outputRect.top,
+                right: outputRect.right,
+                bottom: outputRect.top + outputWidth,
+                left: outputRect.left
+            };
+        } else {
+            var outputHeight = outputRect.bottom - outputRect.top;
+
+            pixmapSettings.inputRect = {
+                top: inputRect.top,
+                right: inputRect.left + inputHeight,
+                bottom: inputRect.bottom,
+                left: inputRect.left
+            };
+
+            pixmapSettings.outputRect = {
+                top: outputRect.top,
+                right: outputRect.left + outputHeight,
+                bottom: outputRect.bottom,
+                left: outputRect.left
+            };
+        }
+    };
+
+    /**
      * Get pixmap data for the given component.
      * 
      * @private
@@ -330,6 +379,16 @@
         }
 
         return settingsPromise.then(function (pixmapSettings) {
+            var hasUniformTranform = component.hasOwnProperty("scale") ||
+                (component.hasOwnProperty("width") && !component.hasOwnProperty("height")) ||
+                (!component.hasOwnProperty("width") && component.hasOwnProperty("height"));
+
+            // If we know the transform to be uniform before rounding errors, then
+            // force the transform to appear uniform to Photoshop
+            if (hasUniformTranform) {
+                this._ensureUniformTransform(pixmapSettings);
+            }
+
             if (this._useSmartScaling !== undefined) {
                 pixmapSettings.useSmartScaling = this._useSmartScaling;
             }


### PR DESCRIPTION
Photoshop only scales layer effects when generating pixmaps that are transformed uniformly. When the image assets plugin generates assets that are relatively scaled, or scaled with wildcards, the transformations are necessarily uniform. Rounding errors, however, can cause Photoshop to perform a slightly non-uniform transformation. For example, a 100x99px asset scaled at 50% should be a uniform transformation, but when the output bounds are correctly calculated to be 50x50px the transformation appears non-uniform. The pull request solves this problem by updating the input and output bounds to correctly reflect the desired uniform transformation in the aforementioned situations, when the transformation is known to be uniform.

Addresses adobe-photoshop/generator-core#211.

Note that this causes some automation assets tests to fail. I've looked at all the failures and the new assets all seem no less correct than the existing assets. (Sometimes they're neither better nor worse, but different.) I'll update the tests in a separate pull request.

CC @joelrbrandt 
