### PR TITLE
Improve accuracy of scaling via uniform transformations

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -386,7 +386,7 @@
             // If we know the transform to be uniform before rounding errors, then
             // force the transform to appear uniform to Photoshop so that effects
             // are necessarily scaled.
-            if (hasUniformTranform && hasEffects) {
+            if (hasUniformTranform) {
                 this._ensureUniformTransform(pixmapSettings);
             }
 


### PR DESCRIPTION
In #246 I added a code path for scaling assets by forcing the pixmap settings to describe explicitly uniform transformations. But I didn't do a very good job because I described the transformation in terms of the _contained_ squares instead of the _containing_ squares. That is, I contracted the input and output rectangles into squares to describe the scaling instead of expanding them. The latter approach deviates less from the ideal scaling factor. This pull request changes the expansion to contraction. It also ONLY applies this transformation for layers that have effects enabled because doing so may describe the scale less accurately, and we only want to do that when necessary to force effects to be scaled.

This breaks some of the automation tests again, but I've verified in each case that the results are more sensible now than they were before.
