### PR TITLE
Allow configuration of a base directory for generated assets

### DIFF
--- a/lib/filemanager.js
+++ b/lib/filemanager.js
@@ -265,7 +265,15 @@
             // Note that on Windows, a deleted file is reported without an absolute path
             isSaved = document.saved && document.file.indexOf("/.Trashes/") === -1,
             documentDirectory = isSaved ? document.directory : _desktopDirectory,
-            basePath = documentDirectory ? path.resolve(documentDirectory, documentName + "-assets") : null;
+            basePath;
+
+        if (this._config.hasOwnProperty("base-directory")) {
+            basePath = path.resolve(this._config["base-directory"], documentName + "-assets");
+        } else if (documentDirectory) {
+            basePath = path.resolve(documentDirectory, documentName + "-assets");
+        } else {
+            basePath = null;
+        }
 
         var previousBasePath = this._basePath;
 


### PR DESCRIPTION
This pull request makes it possible to configure a base directory into which assets are generated. If this configuration option is present, then assets from `document.psd` are generated into `your-specified-base-directory/document-assets/`.
