### PR TITLE
add "use-pngquant" config option

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -70,6 +70,11 @@
         if (config.hasOwnProperty("use-psd-smart-object-pixel-scaling")) {
             this._forceSmartPSDPixelScaling = !!config["use-psd-smart-object-pixel-scaling"];
         }
+
+        if (config.hasOwnProperty("use-pngquant")) {
+            this._usePngquant = !!config["use-pngquant"];
+        }
+
     }
 
     /**
@@ -91,6 +96,11 @@
      * @type {boolean=}
      */
     BaseRenderer.prototype._forceSmartPSDPixelScaling = undefined;
+
+    /**
+     * @type {boolean=}
+     */
+    BaseRenderer.prototype._usePngquant = undefined;
 
     /**
      * Convert a value in a given unit, at particular resolution, to a value in pixels per inch.
@@ -427,6 +437,10 @@
                         ppi: ppi,
                         padding: padding
                     };
+
+                if (this._usePngquant !== undefined) {
+                    settings.usePngquant = this._usePngquant;
+                }
 
                 return {
                     pixmap: pixmap,


### PR DESCRIPTION
Add config option `use-pngquant` to enable pngquant pipeline. Requires adobe-photoshop/generator-core#236

Also, adobe-photoshop/generator-assets-automation@2506737d includes a test of this option.
