### PR TITLE
Check for conflicting asset paths instead of filenames

### DIFF
--- a/lib/componentmanager.js
+++ b/lib/componentmanager.js
@@ -141,7 +141,7 @@
         this._parserManager = new ParserManager(config);
         this._allComponents = {};
         this._componentsForLayer = {};
-        this._filenames = {};
+        this._paths = {};
         this._defaultLayerId = null;
     }
 
@@ -166,11 +166,11 @@
     ComponentManager.prototype._componentsForLayer = null;
 
     /**
-     * The set of component filenames. Used to check for conflicting names
+     * The set of component paths. Used to check for conflicting paths.
      * 
      * @type {{string: boolean}}
      */
-    ComponentManager.prototype._filenames = null;
+    ComponentManager.prototype._paths = null;
 
     /**
      * The layer ID that contains a default component specification, if any.
@@ -188,10 +188,11 @@
      *      like duplicate asset file names or duplicate defaults layers.
      */
     ComponentManager.prototype.addComponent = function (layer, component) {
+        var assetPath = _getAssetPath(component);
 
         if (component.file) {
-            if (this._filenames.hasOwnProperty(component.file)) {
-                throw new Error("Duplicate file name: " + component.file);
+            if (this._paths.hasOwnProperty(assetPath)) {
+                throw new Error("Duplicate path: " + assetPath);
             }
         } else if (component.default) {
             var specName;
@@ -203,8 +204,8 @@
             }
 
             // FIXME: this is not quite right because we don't yet detect
-            // when derived componetns will have conflicting filenames. 
-            if (this._filenames.hasOwnProperty(specName)) {
+            // when derived components will have conflicting filenames.
+            if (this._paths.hasOwnProperty(specName)) {
                 throw new Error("Duplicate default specification: " + specName);
             }
         }
@@ -220,10 +221,10 @@
 
         component.id = componentId;
         component.layer = layer;
-        component.assetPath = _getAssetPath(component);
+        component.assetPath = assetPath;
 
         this._allComponents[componentId] = component;
-        this._filenames[component.file] = true;
+        this._paths[assetPath] = true;
 
         if (!this._componentsForLayer.hasOwnProperty(layer.id)) {
             this._componentsForLayer[layer.id] = {};
@@ -260,7 +261,7 @@
         }
 
         delete this._allComponents[componentId];
-        delete this._filenames[component.file];
+        delete this._paths[_getAssetPath(component)];
     };
 
     /**


### PR DESCRIPTION
This fixes a bug in which asset specifications for different subfolders are marked as conflicting when their filenames were equal. That is, an error is reported to the user when trying to generate `foo/layer1.png` and `bar/layer1.png`. This pull request addresses the problem at component-registration time by checking for conflicts against existing paths instead of existing filenames.

Addresses Watson issue 3803716 filed by @itoda. Please review, @volfied or @joelrbrandt.
