### PR TITLE
correct documentation for _selection property

### DIFF
--- a/lib/dom/document.js
+++ b/lib/dom/document.js
@@ -223,7 +223,8 @@
     Document.prototype._bounds = null;
 
     /**
-     * @type {{number, boolean}}
+     * @type {{string, Layer}}
+     * Map of currently selected layers. Keys are layer IDs as strings, values are Layer objects
      */
     Document.prototype._selection = null;
 


### PR DESCRIPTION
@iwehrman I'm pretty sure this is (more) correct.

It seems like it would actually be better if the selection property were just an array of Layer objects. But, making that change would probably break existing stuff (in particular, it would definitely break some code I just wrote).
