### PR TITLE
fix layer rename leaving dangling specifications

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -363,9 +363,7 @@
                         }
                     }, this);
 
-                if (validSpecifications.length > 0) {
-                    specifications[layer.id] = validSpecifications;
-                }
+                specifications[layer.id] = validSpecifications;
 
                 return specifications;
             }.bind(this), {});


### PR DESCRIPTION
The asset manager finishes processing changes by iterating the specifications object .  There is working code to remove components if a layer name was ‘player.png’ and is now just ‘player’...

https://github.com/adobe-photoshop/generator-assets/blob/jhatwich/layer-update/lib/assetmanager.js#L416

...but leaving empty arrays out of the specifications object prevented it from running.
