### PR TITLE
log invalid layerComp scale to errors.txt

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -185,7 +185,14 @@
                         "Default spec in layer comp names are unsupported.", "Layer Comp");
                 }
             } else {
-                console.warn("result.component not found, instead " + JSON.stringify(result));
+                if (result.errors) {
+                    result.errors.forEach(function (errMsg) {
+                        this._errorManager.addError(comp, errMsg, "Layer Comp");
+                    }.bind(this));
+                    
+                } else {
+                    console.warn("result.component not found, instead " + JSON.stringify(result));
+                }
             }
         }.bind(this));
     };


### PR DESCRIPTION
Fixes a bug @iwehrman  found where changing a layer comp name to have a 0% prefix, yields the error message below in the console.  The error message is now logged to errors.txt

debug:generator-assets 07:39:25.392 assetmanager.js:442:22] handleChange: { comps: 
   { '1533345388': 
      { id: 1533345388,
        name: '0% Layer Coooomp 2.png8',
        position: false,
        visibility: true,
        appearance: false,
        layerSettings: [Object],
        type: 'changed' } },
  id: 35,
  timeStamp: 1408977565.388,
  count: 10 }
result.component not found, instead {"errors":["Invalid scale: 0%"]}
