### PR TITLE
Fix approximate bounds for layer comp assets

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -30,6 +30,8 @@
     var tmp = require("tmp"),
         Q = require("q");
 
+    var Bounds = require("./dom/bounds");
+
 
     /**
      * Asynchronously get a unique temporary path name.
@@ -346,7 +348,8 @@
             }
             
         }, this);
-        return bounds;
+
+        return new Bounds(bounds);
     };
     
     /**
@@ -436,42 +439,40 @@
 
     /**
      * Synchronously get approximate bounds for the given component. These bounds
-     * should only be used if layer pixmap is scaled by an integral multiple and if
+     * should only be used if pixmap is scaled by an integral multiple and if
      * there is no mask and there are no enabled layer effects.
      *
      * @private
-     * @param {Layer} layer
      * @param {Component} component
      * @return {{inputRect: Bounds, outputRect: Bounds, expectedWidth: number,
      *      expectedHeight: number, getPadding: function (number, number): number }}
      */
-    PixmapRenderer.prototype._getSettingsWithApproximateBounds = function (layer, component) {
+    PixmapRenderer.prototype._getSettingsWithApproximateBounds = function (component) {
         var scalar = component.scale;
         if (!scalar) {
             scalar = 1;
         }
 
-        var inputRect = layer.bounds,
-            outputRect = inputRect.scale(scalar);
+        var inputRect,
+            paddedBounds;
+        if (component.layer) {
+            inputRect = component.layer.bounds;
+            paddedBounds = inputRect;
+        } else { // layer comp
+            inputRect = this._getContentBounds(component.document);
+            paddedBounds = component.document.bounds;
+        }
 
+        var outputRect = inputRect.scale(scalar);
         if (outputRect.right <= outputRect.left || outputRect.bottom <= outputRect.top) {
             throw new Error("Refusing to render pixmap with zero bounds.");
         }
 
-        return {
-            inputRect: inputRect,
-            outputRect: outputRect,
-            expectedWidth: outputRect.right - outputRect.left,
-            expectedHeight: outputRect.bottom - outputRect.top,
-            getPadding: function () {
-                return {
-                    top: 0,
-                    right: 0,
-                    bottom: 0,
-                    left: 0
-                };
-            }
+        var settings = {
+            scaleX: scalar,
+            scaleY: scalar
         };
+        return this._generator.getPixmapParams(settings, inputRect, inputRect, paddedBounds);
     };
 
     /**
@@ -542,7 +543,6 @@
                 component.hasOwnProperty("width") || component.hasOwnProperty("height"),
             layer = component.layer,
             layerComp = component.comp,
-            doc = component.document,
             settingsPromise,
             resultPromise,
             hasMask = layer && layer.mask && layer.mask.enabled,
@@ -556,7 +556,7 @@
             //we can get away with the faster check
             try {
                 //if not a layer, its a layerComp and we want the doc bounds
-                settingsPromise = Q.resolve(this._getSettingsWithApproximateBounds(layer || doc, component));
+                settingsPromise = Q.resolve(this._getSettingsWithApproximateBounds(component));
             } catch (ex) {
                 settingsPromise = Q.reject(ex);
             }


### PR DESCRIPTION
I spoke a bit too soon about #275 completely fixing #273... That PR fixed the bounds calculation for layer comps in the "exact bounds" path, but not the "approximate bounds" path. This manifested itself in the [original test PSD](http://cloud.wehrman.org/0d3n1J3M2Z3C) by yielding assets with trivial scaling (i.e., an integer scaling factor) that use the visible bounds for padding (i.e., no padding), and by creating assets with non-trivial scaling that instead use the document bounds for padding. This changes the bounds computation for assets with trivial scaling (i.e., approximate bounds computation) to also use the document bounds for padding. As a result, the document bounds are now always used for the bounds of generated assets. 

This differs somewhat from the way we generate layer assets, in which the bounds of generated assets always correspond to the layer bounds cropped to visible pixels. I think this is reasonable behavior though, given that the ostensible purpose of the layer comps feature is to create whole-document previews. Either way, at least it's consistent...

@jhatwich do you have time to test and review this? This is stuff probably fresher in your head than anyone else's. If not, just let me know and I'll twist @joelrbrandt's arm. I've confirmed that the assets generated for the aforementioned test PSD look correct, and that there aren't any regressions in the automated tests, but I hope someone will check my work!
