### PR TITLE
Expose the webp-lossless setting in generator-core as a config option

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -81,6 +81,9 @@
             this._usePngquant = !!config["use-pngquant"];
         }
 
+        if (config.hasOwnProperty("webp-lossless")) {
+            this._webpLossless = !!config["webp-lossless"];
+        }
     }
 
     /**
@@ -115,6 +118,13 @@
      * @type {boolean=}
      */
     BaseRenderer.prototype._usePngquant = undefined;
+
+    /**
+     * @type {boolean=}
+     * Indicates whether webp assets should be compressed losslessly. By default,
+     * they are not.
+     */
+    BaseRenderer.prototype._webpLossless = undefined;
 
     /**
      * Convert a value in a given unit, at particular resolution, to a value in pixels per inch.
@@ -631,6 +641,10 @@
                 
                 if (this._usePngquant !== undefined) {
                     settings.usePngquant = this._usePngquant;
+                }
+
+                if (this._webpLossless !== undefined) {
+                    settings.lossless = this._webpLossless;
                 }
 
                 return {


### PR DESCRIPTION
If `webp-lossless` is true and webp assets are generated, this causes convert to use lossless compression. This is off by default because it's slow as a :dog:. 

This is a low-risk change, but it also doesn't need to go in for 15.2.

CC @joelrbrandt 
