### PR TITLE
layer-comp-folder to separate layer comp output

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -71,6 +71,12 @@
         this._config = config;
         this._logger = logger;
         this._document = document;
+        
+        if (config["layer-comp-folder"] !== undefined) {
+            this._layerCompFolder = config["layer-comp-folder"];
+        } else {
+            this._layerCompFolder = "layer-comps";
+        }
 
         this._renderManager = renderManager;
         this._fileManager = new FileManager(generator, config, logger);
@@ -118,6 +124,11 @@
      */
     AssetManager.prototype._componentManager = null;
 
+    /**
+     * @type {string}
+     */
+    AssetManager.prototype._layerCompFolder = null;
+    
     /**
      * Cancel render jobs and remove assets for all the components derived from
      * the basic component referred to by the given componentId.
@@ -172,6 +183,10 @@
             if (result.component) {
                 if (!result.component.default) {
                     try {
+                        if (this._layerCompFolder) {
+                            result.component.folder = [this._layerCompFolder].concat(result.component.folder || []);
+                            result.component.name = this._layerCompFolder + "/" + result.component.name;
+                        }
                         result.component.document = doc;
                         result.component.comp = comp;
                         result.component.assetPath = result.component.file;


### PR DESCRIPTION
With this change layer comps are always saved a folder called "layer-comps" or a folder provided by adding config "layer-comp-folder"

This change is being proposed for 15.2 and should also go into the release branch (provided we are all happy with it).