### PR TITLE
get extact bounds if initial bounds weren't calculated

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -558,6 +558,7 @@
         // 2. The layer does not have an enabled mask
         // 3. The layer does not have any enabled layer effects
         // 4. The "include-ancestor-masks" config option is NOT set
+        // 5. The layer has non-zero bounds. Sometimes they aren't computed and set to all 0's
         var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
                 component.hasOwnProperty("width") || component.hasOwnProperty("height"),
             layer = component.layer,
@@ -565,10 +566,14 @@
             settingsPromise,
             resultPromise,
             hasMask = layer && layer.mask && layer.mask.enabled,
-            hasEffects = layer && layer.layerEffects && layer.layerEffects.isEnabled();
+            hasEffects = layer && layer.layerEffects && layer.layerEffects.isEnabled(),
+            hasZeroBounds = layer && (!layer.bounds || (layer.bounds.top === 0 &&
+                                                        layer.bounds.bottom === 0 &&
+                                                        layer.bounds.left === 0 &&
+                                                        layer.bounds.right === 0));
         
         //hasComplexTransform is the only part of this test that affects layerComp
-        if (hasComplexTransform || hasMask || hasEffects || (layer && this._includeAncestorMasks)) {
+        if (hasComplexTransform || hasMask || hasEffects || hasZeroBounds || (layer && this._includeAncestorMasks)) {
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {


### PR DESCRIPTION
We've hit some files where the initial layer bounds are not getting calculated. Even though we rename them with a ".png" no files are getting generated because the bounds returned from the first complete grab didn't get them. If we force the exact bounds code in these cases the images do render. 
