### PR TITLE
Propagate exact bounds errors back through the deferred

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -451,7 +451,7 @@
                     visibleBounds, paddedBounds);
             
             resultDeferred.resolve(pixmapSettings);
-        }.bind(this));
+        }.bind(this)).fail(resultDeferred.reject);
         
         return resultDeferred.promise;
     };


### PR DESCRIPTION
If getting exact bounds does return a zero bounds error, the throw in the .then() was leaving the resultDeferred dangling. Since we `done` is fun I added one here too. 
