### PR TITLE
temporarily force pixel scaling of smart object psds 

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -111,8 +111,13 @@
 
     /**
      * @type {boolean=}
+     * TODO: As reported in Watson #3824265, attempting to scale smart object PSDs intelligently
+     * (i.e. not pixel scaling) fails if the smart object PSD only contains a background layer.
+     * We are temporarily forcing pixel scaling. This will be referted (to undefined) when
+     * Watson #3824265 is fixed. (And, it currently can be overridden with the
+     * "use-psd-smart-object-pixel-scaling" config option.)
      */
-    BaseRenderer.prototype._forceSmartPSDPixelScaling = undefined;
+    BaseRenderer.prototype._forceSmartPSDPixelScaling = true;
 
     /**
      * @type {boolean=}


### PR DESCRIPTION
workaround for Watson 3824265
