### PR TITLE
remove unnecessary else branch in SVG renderer constructor

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -177,8 +177,6 @@
         
         if (config.hasOwnProperty("svgomg-enabled")) {
             this._useSVGOMG = !!config["svgomg-enabled"];
-        } else {
-            this._useSVGOMG = true;
         }
     }
 


### PR DESCRIPTION
Now that SVGOMG is enabled by default, this else branch is no longer necessary. (The value of `_useSVGOMG` is `true` in the prototype.)
