### PR TITLE
windows does not like copying to the same dest as the source, especially...

### DIFF
--- a/lib/filemanager.js
+++ b/lib/filemanager.js
@@ -279,7 +279,7 @@
 
         if (basePath) {
             this._basePath = basePath;
-            if (previousBasePath) {
+            if (previousBasePath && this._basePath !== previousBasePath) {
                 this._updateBaseDirectory(previousBasePath);
             } else {
                 this._queue.unpause();


### PR DESCRIPTION
... when explorer has the path open

This fixes a bug present in windows. 

Create a file with a few layers with valid suffixes (.png) and add  default 100%, 200% scaled-at-200/@2x close photoshop and save to your documents folder. Re open photoshop and the folder you just saved to your documents folder. Start extraction of assets through the file menu. Make some changes to the layer to ensure assets have extracted.
Open the folder scaled-at-200 and leave open
Delete the default settings layer.
Generator will throw an exception. In some cases it will also delete all your previously extracted assets. 
