### PR TITLE
handle errors resulting from documents that are closed before we ask about them

### DIFF
--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -515,7 +515,9 @@
 
         // We don't know anything about this document; fetch it from Photoshop
         var deferred = this._initDocument(id);
-
+        deferred.promise.fail(function () {
+            this._removeOpenDocumentID(id);
+        }.bind(this));
         return deferred.promise;
     };
 

--- a/main.js
+++ b/main.js
@@ -106,6 +106,9 @@
         open.forEach(function (id) {
             _documentManager.getDocument(id).done(function (document) {
                 document.on("generatorSettings", _handleDocGeneratorSettingsChange.bind(undefined, id));
+            }, function (error) {
+                _logger.warning("Error getting document during a document changed event, " +
+                    "document was likely closed.", error);
             });
         });
     }


### PR DESCRIPTION
The "Share on Behance" plug-in blocks ExtendScript while it executes. It also creates and then closes a document.

We don't properly handle the case where a document is opened and then closed before we get around to asking about the document.

This PR fixes that bug.

cc @iwehrman @jhatwich 
