### PR TITLE
Clip images to document bounds

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -204,7 +204,7 @@
      * 
      * @private
      */
-    AssetManager.prototype._init = function () {
+    AssetManager.prototype._init = function (resetLayerBounds) {
         this._renderPromises = {};
         this._filePromises = [];
         this._componentManager = new ComponentManager(this._generator, this._config, this._logger);
@@ -229,6 +229,9 @@
                 var component = result.component;
                 if (component) {
                     try {
+                        if (resetLayerBounds) {
+                            component.needsLayerBoundsUpdate = true;
+                        }
                         this._componentManager.addComponent(layer, component);
                         hasValidComponent = true;
                     } catch (ex) {
@@ -295,9 +298,9 @@
      * 
      * @private
      */
-    AssetManager.prototype._reset = function () {
+    AssetManager.prototype._reset = function (resetLayerBounds) {
         this._cleanup();
-        this._init();
+        this._init(resetLayerBounds);
     };
 
     /**
@@ -483,7 +486,7 @@
         }
 
         if (change.resolution || change.bounds) {
-            this._reset();
+            this._reset(true);
         }
 
         if (change.comps) {

--- a/lib/dom/bounds.js
+++ b/lib/dom/bounds.js
@@ -173,6 +173,54 @@
             right: (this.right - this.left) * scalar
         });
     };
+    
+    /**
+     * get the intersection of this bounds and another
+     * 
+     * @param {Bounds} other bounds to check for intersections
+     * @return {Bounds}
+     */
+    Bounds.prototype.intersect = function (other) {
+        var intersect = new Bounds({
+            top: Math.max(this.top, other.top),
+            left: Math.max(this.left, other.left),
+            bottom: Math.min(this.bottom, other.bottom),
+            right: Math.min(this.right, other.right)
+        });
+        
+        if (intersect.isEmpty()) {
+            intersect = new Bounds({top: 0, left: 0, bottom: 0, right: 0});
+        }
+        return intersect;
+    };
+    
+    /**
+     * get the union of this bounds and another
+     * 
+     * @param {Bounds} other bounds to expand to contain
+     * @return {Bounds}
+     */
+    Bounds.prototype.union = function (other) {
+        return new Bounds({
+            top: Math.min(this.top, other.top),
+            left: Math.min(this.left, other.left),
+            bottom: Math.max(this.bottom, other.bottom),
+            right: Math.max(this.right, other.right)
+        });
+    };
+    
+    /**
+     * does this define an area with a width and height
+     * 
+     * @return {bool}
+     */
+    Bounds.prototype.isEmpty = function () {
+        var height = this.bottom - this.top,
+            width = this.right - this.left;
+        
+        return !(Number.isFinite(height) && Number.isFinite(width) &&
+                width > 0 && height > 0);
+    };
 
     module.exports = Bounds;
 }());

--- a/lib/dom/layer.js
+++ b/lib/dom/layer.js
@@ -123,8 +123,10 @@
                 case "path":
                     this._setPath(raw.path);
                     break;
-                case "index":
                 case "type":
+                    this._setType(raw.type);
+                    break;
+                case "index":
                 case "added":
                     // ignore these properties
                     break;
@@ -191,12 +193,18 @@
         "group": {
             get: function () { return this._group; },
             set: function () { throw new Error("Cannot set group"); }
+        },
+        "type": {
+            get: function () { return this._type; },
+            set: function () { throw new Error("Cannot set type"); }
         }
     });
 
     BaseLayer.prototype._document = null;
 
     BaseLayer.prototype._group = null;
+    
+    BaseLayer.prototype._type = null;
 
     BaseLayer.prototype._id = null;
 
@@ -224,6 +232,10 @@
 
     BaseLayer.prototype._setGroup = function (group) {
         this._group = group;
+    };
+    
+    BaseLayer.prototype._setType = function (type) {
+        this._type = type;
     };
 
     BaseLayer.prototype._setName = function (rawName) {
@@ -539,17 +551,21 @@
      * relatively expensive operation. Ideally, the outcome would be cached and
      * reused, and cleared when this layer or any dependent layer is changed.
      * 
+     * @param {boolean} cache Whether to update this layers bounds with the result
      * @return {Promise.<Bounds>}
      */
-    BaseLayer.prototype.getExactBounds = function () {
+    BaseLayer.prototype.getExactBounds = function (cache) {
         var document = this._document,
             generator = document._generator;
 
         return generator.getPixmap(document.id, this.id, EXACT_BOUNDS_SETTINGS)
             .get("bounds")
             .then(function (rawBounds) {
+                if (cache) {
+                    this._updateBounds(rawBounds);
+                }
                 return new Bounds(rawBounds);
-            });
+            }.bind(this));
     };
 
     /**
@@ -593,6 +609,49 @@
 
         return dependents;
     };
+    
+    /**
+     * Gets the bounds of the regular bitmap layer mask if one is applied. If no mask is applied
+     * or the mask is disabled then it returns undefined
+     *
+     * @return {{Bounds} || undefined } The bounds of the bitmap mask or undefined if not mask
+     */
+    BaseLayer.prototype.getBitmapMaskBounds = function () {
+        return this.mask && this.mask.enabled && this.mask.bounds;
+    };
+        
+    /**
+     * Gets the bounds of the vector mask if one is applied. If no vector mask is applied
+     * then it returns undefined
+     *
+     * @return {{Bounds} || undefined } The bounds of the vector mask or undefined if not mask
+     */
+    BaseLayer.prototype.getVectorMaskBounds = function () {
+        return this.path && this.path.bounds;
+    };
+    
+    /**
+     * Gets the union of the layer mask and layer vector mask for the total area that 
+     * should be masked
+     *
+     * @return {{Bounds} || undefined } The bounds of the vector mask or undefined if not mask
+     */
+    BaseLayer.prototype.getTotalMaskBounds = function () {
+        var maskBounds = this.getBitmapMaskBounds(),
+            vectorMaskBounds = this.getVectorMaskBounds();
+        if (maskBounds && maskBounds.isEmpty()) {
+            maskBounds = undefined;
+        }
+        if (vectorMaskBounds && vectorMaskBounds.isEmpty()) {
+            vectorMaskBounds = undefined;
+        }
+        if (maskBounds && vectorMaskBounds) {
+            return maskBounds.union(vectorMaskBounds);
+        }
+        
+        return maskBounds || vectorMaskBounds;
+    };
+    
 
     function Layer(document, group, raw) {
         BaseLayer.call(this, document, group, raw);
@@ -735,6 +794,16 @@
         if (Object.keys(changes).length > 0) {
             return changes;
         }
+    };
+    
+    /**
+     * Overrides the base implemenation because shape layers don't have vector masks, the 
+     * path property describes the shape itself
+     *
+     * @return { undefined } always undefined for shape layers
+     */
+    ShapeLayer.prototype.getVectorMaskBounds = function () {
+        return undefined;
     };
 
     function TextLayer(document, group, raw) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -84,6 +84,14 @@
         if (config.hasOwnProperty("webp-lossless")) {
             this._webpLossless = !!config["webp-lossless"];
         }
+        
+        if (config.hasOwnProperty("clip-all-images-to-document-bounds")) {
+            this._clipAllImagesToDocumentBounds = !!config["clip-all-images-to-document-bounds"];
+        }
+        
+        if (config.hasOwnProperty("mask-adds-padding")) {
+            this._masksAddPadding = !!config["mask-adds-padding"];
+        }
     }
 
     /**
@@ -125,6 +133,20 @@
      * they are not.
      */
     BaseRenderer.prototype._webpLossless = undefined;
+    
+    /**
+     * @type {boolean=}
+     * Indicates whether exported assets should get clipped to the document bounds or not,
+     * defaults to true to clip the assets so it's more WYSIWYG
+     */
+    BaseRenderer.prototype._clipAllImagesToDocumentBounds = true;
+    
+    /**
+     * @type {boolean=}
+     * Indicates whether layer and vector masks that are larget than the layer size should
+     * add padding to the exported image
+     */
+    BaseRenderer.prototype._masksAddPadding = true;
 
     /**
      * Convert a value in a given unit, at particular resolution, to a value in pixels per inch.
@@ -206,6 +228,7 @@
             scale = settings && settings.hasOwnProperty("scale") ? settings.scale : 1,
             width = settings ? settings.width : undefined,
             height = settings ? settings.height : undefined,
+            constrainToDocBounds = settings ? settings.constrainToDocBounds : undefined,
             params,
             compId;
 
@@ -224,7 +247,8 @@
             targetWidth: width,
             targetHeight: height,
             documentId: documentId,
-            compId: compId
+            compId: compId,
+            constrainToDocBounds: constrainToDocBounds
         };
         
         return svgOMG.getGeneratorSVG(this._generator, params).then(
@@ -263,12 +287,22 @@
         
         if (this._useSVGOMG) {
             if (layer) {
+                if (this._clipAllImagesToDocumentBounds) {
+                    var clippedBounds = layer.bounds.intersect(this._document.bounds);
+                    if (clippedBounds.right <= clippedBounds.left || clippedBounds.bottom <= clippedBounds.top) {
+                        var err = new Error("Refusing to render SVG with bounds completely clipped.");
+                        err.outsideDocumentBoundsError = true;
+                        return Q.reject(err);
+                    }
+                    settings.constrainToDocBounds = true;
+                }
                 return this._getSVGOMG(layer.document.id, layer.id, settings);
             } else if (layerComp) {
+                settings.constrainToDocBounds = this._clipAllImagesToDocumentBounds;
                 settings.compId = layerComp.id;
                 return this._getSVGOMG(component.document.id, "all", settings);
             } else {
-                throw new Error("SVG Renderer failed to find an item to render.");
+                return Q.reject(new Error("SVG Renderer failed to find an item to render."));
             }
         } else {
             if (layer) {
@@ -348,29 +382,20 @@
         doc.layers.visit(function (layer) {
             
             var childBounds = layer.bounds,
-                maskBounds = layer.mask && layer.mask.bounds;
+                maskBounds = layer.getTotalMaskBounds();
             
             if (childBounds && (childBounds.right - childBounds.left > 0 || childBounds.bottom - childBounds.top > 0)) {
                 
                 if (!bounds) {
                     bounds = childBounds;
                 } else {
-                    bounds = { // Compute containing rect of the union of the bounds and maskBounds
-                        left:   Math.min(bounds.left,   childBounds.left),
-                        top:    Math.min(bounds.top,    childBounds.top),
-                        right:  Math.max(bounds.right,  childBounds.right),
-                        bottom: Math.max(bounds.bottom, childBounds.bottom)
-                    };
+                    // Compute containing rect of the union of the bounds and maskBounds
+                    bounds.union(childBounds);
                 }
             }
             
             if (maskBounds) {
-                bounds = {  // compute containing rect of intersection of bounds and maskBounds
-                    left:   Math.max(bounds.left,   maskBounds.left),
-                    top:    Math.max(bounds.top,    maskBounds.top),
-                    right:  Math.min(bounds.right,  maskBounds.right),
-                    bottom: Math.min(bounds.bottom, maskBounds.bottom)
-                };
+                bounds.intersect(maskBounds);
             }
             
         }, this);
@@ -422,7 +447,8 @@
                 staticBounds,
                 scaleSettings,
                 visibleBounds,
-                paddedBounds;
+                paddedBounds,
+                clipToBounds;
             
             if (exactBounds.right <= exactBounds.left || exactBounds.bottom <= exactBounds.top) {
                 throw new Error("Refusing to render pixmap with zero bounds.");
@@ -430,10 +456,19 @@
 
             if (layerComp) {
                 staticBounds = exactBounds;
-                
             } else {
-                maskBounds = layer.mask && layer.mask.bounds;
-                staticBounds  = this._generator.getDeepBounds(layer);
+                maskBounds = layer.getTotalMaskBounds();
+                staticBounds  = new Bounds(this._generator.getDeepBounds(layer));
+            }
+            
+            if (this._clipAllImagesToDocumentBounds) {
+                clipToBounds = this._document.bounds;
+                var clippedBounds = exactBounds.intersect(clipToBounds);
+                if (clippedBounds.right <= clippedBounds.left || clippedBounds.bottom <= clippedBounds.top) {
+                    var err = new Error("Refusing to render pixmap with bounds completely clipped.");
+                    err.outsideDocumentBoundsError = true;
+                    throw err;
+                }
             }
             
             scaleSettings = {
@@ -447,15 +482,11 @@
             // Visible: User provided + effects
             visibleBounds = exactBounds;
             // Padded: User provided + effects + padding through layer mask
-            paddedBounds  = !maskBounds ? exactBounds : {
-                left:   Math.min(exactBounds.left,   maskBounds.left),
-                top:    Math.min(exactBounds.top,    maskBounds.top),
-                right:  Math.max(exactBounds.right,  maskBounds.right),
-                bottom: Math.max(exactBounds.bottom, maskBounds.bottom)
-            };
+            paddedBounds  = (maskBounds && this._masksAddPadding) ?
+                                maskBounds.union(exactBounds) : exactBounds;
             
             pixmapSettings = this._generator.getPixmapParams(scaleSettings, staticBounds,
-                    visibleBounds, paddedBounds);
+                    visibleBounds, paddedBounds, clipToBounds);
             
             resultDeferred.resolve(pixmapSettings);
         }.bind(this)).fail(resultDeferred.reject);
@@ -480,9 +511,12 @@
         }
 
         var inputRect,
-            paddedBounds;
-        if (component.layer) {
-            inputRect = component.layer.bounds;
+            paddedBounds,
+            clipToBounds,
+            layer = component.layer;
+        
+        if (layer) {
+            inputRect = layer.bounds;
             paddedBounds = inputRect;
         } else { // layer comp
             inputRect = this._getContentBounds(component.document);
@@ -493,12 +527,22 @@
         if (outputRect.right <= outputRect.left || outputRect.bottom <= outputRect.top) {
             throw new Error("Refusing to render pixmap with zero bounds.");
         }
+        
+        if (this._clipAllImagesToDocumentBounds) {
+            clipToBounds = this._document.bounds;
+            var clippedBounds = inputRect.intersect(clipToBounds);
+            if (clippedBounds.right <= clippedBounds.left || clippedBounds.bottom <= clippedBounds.top) {
+                var err = new Error("Refusing to render pixmap with bounds completely clipped.");
+                err.outsideDocumentBoundsError = true;
+                throw err;
+            }
+        }
 
         var settings = {
             scaleX: scalar,
             scaleY: scalar
         };
-        return this._generator.getPixmapParams(settings, inputRect, inputRect, paddedBounds);
+        return this._generator.getPixmapParams(settings, inputRect, inputRect, paddedBounds, clipToBounds);
     };
 
     /**
@@ -566,13 +610,16 @@
         // 3. The layer does not have any enabled layer effects
         // 4. The "include-ancestor-masks" config option is NOT set
         // 5. The layer has non-zero bounds. Sometimes they aren't computed and set to all 0's
+        // 5. The layer is clipped, in which case layer.bounds id the clipped size and not the layer size
         var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
                 component.hasOwnProperty("width") || component.hasOwnProperty("height"),
             layer = component.layer,
             layerComp = component.comp,
             settingsPromise,
             resultPromise,
-            hasMask = layer && layer.mask && layer.mask.enabled,
+            isClipped = layer && layer.clipped,
+            hasMask = layer && layer.getTotalMaskBounds(),
+            includeAcestorMasks = layer && this._includeAncestorMasks,
             hasEffects = layer && layer.layerEffects && layer.layerEffects.isEnabled(),
             hasZeroBounds = layer && (!layer.bounds || (layer.bounds.top === 0 &&
                                                         layer.bounds.bottom === 0 &&
@@ -580,14 +627,21 @@
                                                         layer.bounds.right === 0));
         
         //hasComplexTransform is the only part of this test that affects layerComp
-        if (hasComplexTransform || hasMask || hasEffects || hasZeroBounds || (layer && this._includeAncestorMasks)) {
+        if (hasComplexTransform || hasMask || hasEffects || hasZeroBounds || isClipped || includeAcestorMasks) {
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {
             //we can get away with the faster check
             try {
-                //if not a layer, its a layerComp and we want the doc bounds
-                settingsPromise = Q.resolve(this._getSettingsWithApproximateBounds(component));
+                if (component.needsLayerBoundsUpdate) {
+                    settingsPromise = component.layer.getExactBounds(true).then(function () {
+                        delete component.needsLayerBoundsUpdate;
+                        return Q.resolve(this._getSettingsWithApproximateBounds(component));
+                    }.bind(this));
+                } else {
+                    //if not a layer, its a layerComp and we want the doc bounds
+                    settingsPromise = Q.resolve(this._getSettingsWithApproximateBounds(component));
+                }
             } catch (ex) {
                 settingsPromise = Q.reject(ex);
             }
@@ -641,6 +695,8 @@
             var fnHandlePixmap = function (pixmap) {
                 var padding = pixmapSettings.hasOwnProperty("getPadding") ?
                         pixmapSettings.getPadding(pixmap.width, pixmap.height) : undefined,
+                    extract =  pixmapSettings.hasOwnProperty("getExtractParamsForDocBounds") ?
+                        pixmapSettings.getExtractParamsForDocBounds(pixmap.width, pixmap.height) : undefined,
                     quality = component.quality,
                     format = component.extension,
                     ppi = this._document.resolution,
@@ -648,8 +704,38 @@
                         quality: quality,
                         format: format,
                         ppi: ppi,
-                        padding: padding
+                        padding: padding,
+                        extract: extract
                     };
+                
+                if (padding && (padding.top || padding.left || padding.right || padding.bottom) && extract) {
+                    //shuffle padding out of the extract coordinates so they don't compete
+                    var clip, delta;
+                    if (padding.right) {
+                        clip = pixmap.width - extract.width - extract.x;
+                        delta = Math.min(clip, padding.right);
+                        extract.width += delta;
+                        padding.right -= delta;
+                    }
+                    if (padding.bottom) {
+                        clip = pixmap.height - extract.height - extract.y;
+                        delta = Math.min(clip, padding.bottom);
+                        extract.height += delta;
+                        padding.bottom -= delta;
+                    }
+                    if (padding.left) {
+                        delta = Math.min(extract.x, padding.left);
+                        extract.x -= delta;
+                        extract.width += delta;
+                        padding.left -= delta;
+                    }
+                    if (padding.top) {
+                        delta = Math.min(extract.y, padding.top);
+                        extract.y -= delta;
+                        extract.height += delta;
+                        padding.top -= delta;
+                    }
+                }
                 
                 if (this._usePngquant !== undefined) {
                     settings.usePngquant = this._usePngquant;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -44,7 +44,7 @@
     "svgobjectmodelgenerator": {
       "version": "0.0.1",
       "from": "svgobjectmodelgenerator@git+https://github.com/adobe-research/svgObjectModelGenerator.git#release-0.2",
-      "resolved": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#7b9de6c3b10928f9c503a4aedcdd3c4c014a5460"
+      "resolved": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#26cd365306ea5534ca84b73cd4f26fc0c6b6d0ea"
     },
     "tmp": {
       "version": "0.0.24",


### PR DESCRIPTION
This adds an option `clip-all-images-to-document-bounds` to clip the images getting exported to the document bounds. The exception is any image with vector masks will always get clipped to the layer mask and not the document bounds.
