### PR TITLE
drive by meta-data

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -650,9 +650,10 @@
                     currentComponents.forEach(function (component) {
                         try {
                             var componentId = this._componentManager.addComponent(layer, component);
-                            this._componentManager.getDerivedComponents(componentId).forEach(function (derivedComponent) {
-                                this._requestRender(derivedComponent);
-                            }, this);
+                            this._componentManager.getDerivedComponents(componentId).forEach(
+                                function (derivedComponent) {
+                                    this._requestRender(derivedComponent);
+                                }, this);
                         } catch (ex) {
                             this._errorManager.addError(layer, ex.message);
                         }

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -26,7 +26,8 @@
 
     var events = require("events"),
         os = require("os"),
-        util = require("util");
+        util = require("util"),
+        META_PLUGIN_ID = "crema";
 
     var Q = require("q");
 
@@ -168,32 +169,34 @@
      * @param {object} compComponents a lookup of components by component Id
      */
     AssetManager.prototype._addComponentsForComp = function (comp, doc, compComponents) {
-        this._componentManager.findAllComponents(comp).forEach(function (result) {
-            if (result.component) {
-                if (!result.component.default) {
-                    try {
-                        result.component.document = doc;
-                        result.component.comp = comp;
-                        result.component.assetPath = result.component.file;
-                        this._componentManager.addLayerCompComponent(result.component);
-                        compComponents.push(result.component);
-                    } catch (err) {
-                        this._errorManager.addError(comp, err.message, "Layer Comp");
+        return this._componentManager.findAllComponents(comp).then(function (components) {
+            components.forEach(function (result) {
+                if (result.component) {
+                    if (!result.component.default) {
+                        try {
+                            result.component.document = doc;
+                            result.component.comp = comp;
+                            result.component.assetPath = result.component.file;
+                            this._componentManager.addLayerCompComponent(result.component);
+                            compComponents.push(result.component);
+                        } catch (err) {
+                            this._errorManager.addError(comp, err.message, "Layer Comp");
+                        }
+                    } else {
+                        this._errorManager.addError(comp,
+                            "Default spec in layer comp names are unsupported.", "Layer Comp");
                     }
                 } else {
-                    this._errorManager.addError(comp,
-                        "Default spec in layer comp names are unsupported.", "Layer Comp");
+                    if (result.errors) {
+                        result.errors.forEach(function (errMsg) {
+                            this._errorManager.addError(comp, errMsg, "Layer Comp");
+                        }.bind(this));
+
+                    } else {
+                        console.warn("result.component not found, instead " + JSON.stringify(result));
+                    }
                 }
-            } else {
-                if (result.errors) {
-                    result.errors.forEach(function (errMsg) {
-                        this._errorManager.addError(comp, errMsg, "Layer Comp");
-                    }.bind(this));
-                    
-                } else {
-                    console.warn("result.component not found, instead " + JSON.stringify(result));
-                }
-            }
+            }.bind(this));
         }.bind(this));
     };
     
@@ -207,7 +210,7 @@
     AssetManager.prototype._init = function (resetLayerBounds) {
         this._renderPromises = {};
         this._filePromises = [];
-        this._componentManager = new ComponentManager(this._generator, this._config, this._logger);
+        this._componentManager = new ComponentManager(this._generator, this._config, this._logger, this._document);
         this._fileManager.updateBasePath(this._document);
         this._errorManager.removeAllErrors();
         this._renderManager.cancelAll(this._document.id);
@@ -215,38 +218,76 @@
         var layerIdsWithComponents = [],
             compComponents = [],
             doc = this._document,
-            comps = doc._comps;
+            comps = doc._comps,
+            aLayerPromises = [],
+            docDefer = Q.defer();
+        
+        aLayerPromises.push(docDefer.promise);
+        
+        this._generator.getDocumentSettingsForPlugin(doc.id, META_PLUGIN_ID).then(function (docMeta) {
+            if (docMeta && docMeta.metaEnabled) {
+                this._componentManager._defaultComponents = [];
+                //read the default layer spec
+                if (docMeta.scaleSettings) {
+                    docMeta.scaleSettings.forEach(function (spec) {
+                        
+                        //make the spec as-expected for component manager
+                        
+                        if (!spec.folder) {
+                            spec.folder = ["/"];
+                        } else if (typeof spec.folder === "string") {
+                            spec.folder = [spec.folder];
+                        }
+                        if (!spec.file) {
+                            spec.file = "";
+                        }
+                        
+                        this._componentManager._defaultComponents.push(spec);
+                        this._componentManager.addMetaComponent(spec);
+                    }, this);
+                }
+            }
+            docDefer.resolve();
+        }.bind(this));
         
         this._document.layers.visit(function (layer) {
             // Don't visit the top-level LayerGroup
             if (!layer.group) {
                 return;
             }
-
-            var hasValidComponent = false;
-
-            this._componentManager.findAllComponents(layer).forEach(function (result) {
-                var component = result.component;
-                if (component) {
-                    try {
-                        if (resetLayerBounds) {
-                            component.needsLayerBoundsUpdate = true;
+            
+            var layerDefer = Q.defer();
+            aLayerPromises.push(layerDefer.promise);
+            
+            this._componentManager.findAllComponents(layer).then(function (components) {
+                var hasValidComponent = false;
+                if (components) {
+                    components.forEach(function (result) {
+                        var component = result.component;
+                        if (component) {
+                            try {
+                                if (resetLayerBounds) {
+                                    component.needsLayerBoundsUpdate = true;
+                                }
+                                this._componentManager.addComponent(layer, component);
+                                hasValidComponent = true;
+                            } catch (ex) {
+                                this._errorManager.addError(layer, ex.message);
+                            }
+                        } else if (result.errors) {
+                            result.errors.forEach(function (error) {
+                                this._errorManager.addError(layer, error);
+                            }.bind(this));
                         }
-                        this._componentManager.addComponent(layer, component);
-                        hasValidComponent = true;
-                    } catch (ex) {
-                        this._errorManager.addError(layer, ex.message);
-                    }
-                } else if (result.errors) {
-                    result.errors.forEach(function (error) {
-                        this._errorManager.addError(layer, error);
-                    }.bind(this));
+                    }, this);
                 }
-            }, this);
-
-            if (hasValidComponent) {
-                layerIdsWithComponents.push(layer.id);
-            }
+            
+                if (hasValidComponent) {
+                    layerIdsWithComponents.push(layer.id);
+                }
+                
+                layerDefer.resolve();
+            }.bind(this));
         }.bind(this));
 
         if (comps) {
@@ -255,10 +296,14 @@
             }.bind(this));
         }
         
-        this._requestRenderForLayers(layerIdsWithComponents);
-        this._requestRenderForComps(compComponents);
-        
-        this._errorManager.reportErrors();
+        Q.all(aLayerPromises).done(function () {
+            this._requestRenderForLayers(layerIdsWithComponents);
+            
+            //TBD: a bit uncertain about the timing of this...
+            this._requestRenderForComps(compComponents);
+            
+            this._errorManager.reportErrors();
+        }.bind(this));
     };
     
     /**
@@ -438,7 +483,8 @@
     AssetManager.prototype._handleCompsChange = function (change) {
         Object.keys(change).forEach(function (compId) {
             var compComponents = this._componentManager.getComponentsByComp(compId),
-                ccTemp;
+                ccTemp,
+                promise;
             
             if (change[compId].type === "removed") {
                 this._errorManager.removeErrors(compId);
@@ -449,7 +495,7 @@
                     this._errorManager.removeErrors(compId);
                     this._cleanupCompComponents(compComponents, true);
                     compComponents = [];
-                    this._addComponentsForComp(change[compId], this._document, compComponents);
+                    promise = this._addComponentsForComp(change[compId], this._document, compComponents);
                 } else {
                     ccTemp = [];
                     Object.keys(compComponents).forEach(function (cmp) {
@@ -457,10 +503,13 @@
                     });
                     this._cleanupCompComponents(compComponents, false);
                     compComponents = ccTemp;
+                    promise = Q.resolve();
                 }
-                compComponents.forEach(function (component) {
-                    this._requestRender(component);
-                }, this);
+                promise.then(function () {
+                    compComponents.forEach(function (component) {
+                        this._requestRender(component);
+                    }, this);
+                }.bind(this));
             }
         }.bind(this));
     };
@@ -485,8 +534,9 @@
             this._fileManager.updateBasePath(this._document);
         }
 
-        if (change.resolution || change.bounds) {
-            this._reset(true);
+        if (change.resolution || change.bounds || change.generatorSettings) {
+            this._reset(!change.generatorSettings);
+            return;
         }
 
         if (change.comps) {
@@ -513,15 +563,20 @@
                 }, dependentLayers);
             }.bind(this), {});
 
+            var allSpecPromises = [];
+            
             // Find all the component specifications for all the changed layers and their dependencies
             var specificationsByLayer = _intKeys(dependentLayers).reduce(function (specifications, layerId) {
                 var layer = dependentLayers[layerId],
-                    validSpecifications = [];
+                    validSpecifications = [],
+                    specDeferred = Q.defer();
 
                 this._errorManager.removeErrors(layerId);
-
-                this._componentManager.findAllComponents(layer)
-                    .forEach(function (specification) {
+                
+                allSpecPromises.push(specDeferred.promise);
+                
+                this._componentManager.findAllComponents(layer).then(function (components) {
+                    components.forEach(function (specification) {
                         var component = specification.component,
                             errors = specification.errors;
 
@@ -533,77 +588,81 @@
                             }, this);
                         }
                     }, this);
-
+                    
+                    specDeferred.resolve();
+                }.bind(this));
                 specifications[layer.id] = validSpecifications;
-
                 return specifications;
             }.bind(this), {});
 
-            // Determine whether or not the changes necessitate a complete reset.
-            // E.g., has a default component changed?
-            var resetRequired = _intKeys(specificationsByLayer).some(function (layerId) {
-                var specifications = specificationsByLayer[layerId];
+            Q.all(allSpecPromises).done(function () {
+            
+                // Determine whether or not the changes necessitate a complete reset.
+                // E.g., has a default component changed?
+                var resetRequired = _intKeys(specificationsByLayer).some(function (layerId) {
+                    var specifications = specificationsByLayer[layerId];
 
-                return specifications.some(function (specification) {
-                    return specification.hasOwnProperty("default");
-                });
-            }, this);
+                    return specifications.some(function (specification) {
+                        return specification.hasOwnProperty("default");
+                    });
+                }, this);
 
-            if (resetRequired) {
-                this._reset();
-                return;
-            }
-
-            // Compute the set of removed layers;
-            // subtract the removed layers from the set of changed layers above 
-            var removedLayerIds = changedLayerIds.filter(function (layerId) {
-                var layerChange = change.layers[layerId];
-                if (layerChange.type === "removed") {
-                    if (specificationsByLayer.hasOwnProperty(layerId)) {
-                        delete specificationsByLayer[layerId];
-                    }
-                    return true;
+                if (resetRequired) {
+                    this._reset();
+                    return;
                 }
-            }, this);
 
-            // Clear out the removed layer components;
-            // remove the assets from the old components and/or cancel their renders
-            removedLayerIds.forEach(function (layerId) {
-                var componentsToRemove = this._componentManager.getComponentsByLayer(layerId);
-
-                Object.keys(componentsToRemove).forEach(function (componentId) {
-                    this._cleanupDerivedComponents(componentId);
-                    this._componentManager.removeComponent(componentId);
-                }, this);
-
-                this._errorManager.removeErrors(layerId);
-            }, this);
-
-            _intKeys(specificationsByLayer).forEach(function (layerId) {
-                var layer = dependentLayers[layerId],
-                    currentComponents = specificationsByLayer[layerId],
-                    previousComponents = this._componentManager.getComponentsByLayer(layerId);
-
-                Object.keys(previousComponents).forEach(function (componentId) {
-                    this._cleanupDerivedComponents(componentId);
-                    this._componentManager.removeComponent(componentId);
-                }, this);
-
-                currentComponents.forEach(function (component) {
-                    try {
-                        var componentId = this._componentManager.addComponent(layer, component);
-                        this._componentManager.getDerivedComponents(componentId).forEach(function (derivedComponent) {
-                            this._requestRender(derivedComponent);
-                        }, this);
-                    } catch (ex) {
-                        this._errorManager.addError(layer, ex.message);
+                // Compute the set of removed layers;
+                // subtract the removed layers from the set of changed layers above 
+                var removedLayerIds = changedLayerIds.filter(function (layerId) {
+                    var layerChange = change.layers[layerId];
+                    if (layerChange.type === "removed") {
+                        if (specificationsByLayer.hasOwnProperty(layerId)) {
+                            delete specificationsByLayer[layerId];
+                        }
+                        return true;
                     }
                 }, this);
-            }, this);
-        }
-        
-        if (change.layers || change.comps) {
-            this._errorManager.reportErrors();
+
+                // Clear out the removed layer components;
+                // remove the assets from the old components and/or cancel their renders
+                removedLayerIds.forEach(function (layerId) {
+                    var componentsToRemove = this._componentManager.getComponentsByLayer(layerId);
+
+                    Object.keys(componentsToRemove).forEach(function (componentId) {
+                        this._cleanupDerivedComponents(componentId);
+                        this._componentManager.removeComponent(componentId);
+                    }, this);
+
+                    this._errorManager.removeErrors(layerId);
+                }, this);
+
+                _intKeys(specificationsByLayer).forEach(function (layerId) {
+                    var layer = dependentLayers[layerId],
+                        currentComponents = specificationsByLayer[layerId],
+                        previousComponents = this._componentManager.getComponentsByLayer(layerId);
+
+                    Object.keys(previousComponents).forEach(function (componentId) {
+                        this._cleanupDerivedComponents(componentId);
+                        this._componentManager.removeComponent(componentId);
+                    }, this);
+
+                    currentComponents.forEach(function (component) {
+                        try {
+                            var componentId = this._componentManager.addComponent(layer, component);
+                            this._componentManager.getDerivedComponents(componentId).forEach(function (derivedComponent) {
+                                this._requestRender(derivedComponent);
+                            }, this);
+                        } catch (ex) {
+                            this._errorManager.addError(layer, ex.message);
+                        }
+                    }, this);
+                }, this);
+            }.bind(this));
+
+            if (change.layers || change.comps) {
+                this._errorManager.reportErrors();
+            }
         }
     };
 

--- a/lib/componentmanager.js
+++ b/lib/componentmanager.js
@@ -24,11 +24,11 @@
 (function () {
     "use strict";
 
-    var path = require("path");
-
-    var ParserManager = require("./parsermanager");
-
-    var _componentIdCounter = 0;
+    var path = require("path"),
+        Q = require("q"),
+        ParserManager = require("./parsermanager"),
+        META_PLUGIN_ID = "crema",
+        _componentIdCounter = 0;
 
     // FIXME: The relationship between basic components, default components and
     // derived components should be made explicit. It's kind of a mess now
@@ -44,6 +44,9 @@
     function _getAssetPath(component) {
         if (component.folder) {
             var folder = component.folder.concat([component.file]);
+            
+            
+            
             return folder.join(path.sep);
         } else {
             return component.file;
@@ -137,13 +140,17 @@
      * 
      * @constructor
      */
-    function ComponentManager(generator, config) {
+    function ComponentManager(generator, config, logger, doc) {
         this._parserManager = new ParserManager(config);
+        this._generator = generator;
+        this._config = config;
+        this._document = doc;
         this._allComponents = {};
         this._componentsForLayer = {};
         this._componentsForComp = {};
         this._paths = {};
         this._defaultLayerId = null;
+        this._defaultComponents = null;
     }
 
     /**
@@ -151,6 +158,22 @@
      */
     ComponentManager.prototype._parserManager = null;
 
+    /**
+     * @type {Generator}
+     */
+    ComponentManager.prototype._generator = null;
+    
+    /**
+     * Generator config preferences
+     * @type {Object}
+     */
+    ComponentManager.prototype._config = null;
+    
+    /**
+     * @type {Document}
+     */
+    ComponentManager.prototype._document = null;
+    
     /**
      * The a set of components, keyed by component ID.
      * 
@@ -187,6 +210,12 @@
      * @type {?number}
      */
     ComponentManager.prototype._defaultLayerId = null;
+    
+    /**
+     * The default components as set by meta-data
+     */
+    ComponentManager.prototype._defaultComponents = null;
+    
 
     ComponentManager.prototype.getComponentId = function () {
         return _componentIdCounter++;
@@ -247,6 +276,13 @@
 
         return componentId;
     };
+    
+    ComponentManager.prototype.addMetaComponent = function (component) {
+        var componentId = this.getComponentId();
+        component.id = componentId;
+
+        this._allComponents[componentId] = component;
+    }
     
     /**
      * Track the provided component, which is contained by the given layer comp.
@@ -397,20 +433,28 @@
      * @return {Array.<Component>}
      */
     ComponentManager.prototype.getDerivedComponents = function (componentId) {
-        var component = this.getComponent(componentId);
+        var component = this.getComponent(componentId),
+            defaultComponents;
 
-        if (this._defaultLayerId === null) {
-            return [component];
-        }
+        if (this._defaultComponents) {
+            defaultComponents = this._defaultComponents;
 
-        if (component.default) {
-            return [];
-        }
+        } else {
+            
+            if (this._defaultLayerId === null) {
+                return [component];
+            }
 
-        var defaultComponentMap = this._componentsForLayer[this._defaultLayerId],
+            if (component.default) {
+                return [];
+            }
+
+            var defaultComponentMap = this._componentsForLayer[this._defaultLayerId];
+
             defaultComponents = Object.keys(defaultComponentMap).map(function (componentId) {
                 return this.getComponent(componentId);
             }, this);
+        }
 
         if (defaultComponents.length === 0) {
             return [component];
@@ -429,28 +473,59 @@
      * 
      * @see ComponentManager.prototype.addComponent
      * @param {Layer} layer The layer from which to extract components
-     * @return {Array.<{errors: Array.<string>} | {component: Component}>}
+     * @return {Promise} resolves to Array.<{errors: Array.<string>} | {component: Component}>}
      */
     ComponentManager.prototype.findAllComponents = function (layer) {
         
-        var results,
-            components = [];
-
-        if (layer.name) {
-            results = this._parserManager.analyzeLayerName(layer.name);
-            results.forEach(function (result) {
-                var errors = result.errors;
-                if (errors.length > 0) {
-                    components.push({errors: errors});
-                } else {
-                    var component = result.component;
-                    if (component.file || component.default) {
-                        components.push({component: component});
-                    }
+        var findAllDeferred = Q.defer(),
+            _G = this._generator,
+            _PM = this._parserManager,
+            doc = this._document,
+            fnFromLayerName = function (layerName) {
+                var aRet = [],
+                    results;
+                if (layerName) {
+                    results = _PM.analyzeLayerName(layerName);
+                    results.forEach(function (result) {
+                        var errors = result.errors;
+                        if (errors.length > 0) {
+                            aRet.push({errors: errors});
+                        } else {
+                            var component = result.component;
+                            if (component.file || component.default) {
+                                aRet.push({component: component});
+                            }
+                        }
+                    });
                 }
-            }, this);
+                return aRet;
+            };
+        
+        if (!this._config["meta-data-driven"]) {
+            findAllDeferred.resolve(fnFromLayerName(layer.name));
+        } else {
+            _G.getDocumentSettingsForPlugin(doc.id, META_PLUGIN_ID).then(function (docMeta) {
+                if (docMeta && docMeta.metaEnabled) {
+                    _G.getLayerSettingsForPlugin(doc.id, layer.id, META_PLUGIN_ID).then(function (layerMeta) {
+                        var components = [];
+                        if (layerMeta && layerMeta.assetSettings) {
+                            layerMeta.assetSettings.forEach(function (setting) {
+
+                                //TBD: translation, if desired
+
+                                components.push({component: setting});
+                            }.bind(this));
+                        }
+                        findAllDeferred.resolve(components);
+                    });
+                } else {
+                    //for now, ignore layer names when in meta-data mode
+                    //findAllDeferred.resolve(fnFromLayerName(layer.name));
+                }
+            });
         }
-        return components;
+        
+        return findAllDeferred.promise;
     };
 
     module.exports = ComponentManager;

--- a/lib/componentmanager.js
+++ b/lib/componentmanager.js
@@ -282,7 +282,7 @@
         component.id = componentId;
 
         this._allComponents[componentId] = component;
-    }
+    };
     
     /**
      * Track the provided component, which is contained by the given layer comp.
@@ -518,9 +518,6 @@
                         }
                         findAllDeferred.resolve(components);
                     });
-                } else {
-                    //for now, ignore layer names when in meta-data mode
-                    //findAllDeferred.resolve(fnFromLayerName(layer.name));
                 }
             });
         }

--- a/main.js
+++ b/main.js
@@ -298,15 +298,15 @@
                         generator.setDocumentSettingsForPlugin({
                             metaEnabled: true,
                             scaleSettings: [{
-                                    scale: 1
-                                },{
-                                    folder: "scaled-at-25/",
-                                    scale: 0.25
-                                },{
-                                    folder: "scaled-at-200/",
-                                    suffix: "@2x",
-                                    scale: 2
-                                }]
+                                scale: 1
+                            }, {
+                                folder: "scaled-at-25/",
+                                scale: 0.25
+                            }, {
+                                folder: "scaled-at-200/",
+                                suffix: "@2x",
+                                scale: 2
+                            }]
                         }, META_PLUGIN_ID);
 
                         //apply some settings to the currently selected layer
@@ -314,11 +314,11 @@
                             layerId = findLayerIdForIndex (doc.layers, doc.selection[0]);
                             generator.setLayerSettingsForPlugin({
                                 assetSettings: [{
-                                name: "30x? layer.png-32",
-                                extension: "png",
-                                quality: 32,
-                                file: "layer.png",
-                                width: 30
+                                    name: "30x? layer.png-32",
+                                    extension: "png",
+                                    quality: 32,
+                                    file: "layer.png",
+                                    width: 30
                                 }]
                             }, layerId, META_PLUGIN_ID);
 


### PR DESCRIPTION
Posting this PR for feedback and collaboration... expecting it will need to be tweaked a bit.

With the config parameter “meta-data-driven” set generator-assets will use meta-data-based export specifications.  Adding the config parameter “meta-data-test-menu-enabled” will add a menu that can be used to force a layer spec onto the current selection.

The meta-data is structured similarly to the objects that come from the layer name parsing in order to limit potential fallout.  The structure of the meta-data is expected to evolve, but I think it would be easier to do that incrementally.
