### PR TITLE
meta-data driven

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -26,7 +26,8 @@
 
     var events = require("events"),
         os = require("os"),
-        util = require("util");
+        util = require("util"),
+        META_PLUGIN_ID = "crema";
 
     var Q = require("q");
 
@@ -198,6 +199,100 @@
     };
     
     /**
+     * Private getting to retrieve the document wide meta data
+     * 
+     * @private
+     * @return {docMeta} - parsed doc meta object or undefined if not there or parser error
+     */
+    AssetManager.prototype._getDocumentMetaData = function () {
+        var docMetaRaw = this._document._generatorSettings && this._document._generatorSettings[META_PLUGIN_ID];
+        
+        if (docMetaRaw && docMetaRaw.json) {
+            try {
+                return JSON.parse(docMetaRaw.json);
+            } catch (ex) {
+                this._logger.error("_getDocumentMetaData failed to parse json: %s", ex.message);
+            }
+        }
+    };
+    
+    /**
+     * Initialize the default layer support from the document level meta-data
+     * 
+     * @private
+     */
+    AssetManager.prototype._initDefaultMetaComponents = function (docMeta) {
+        this._logger.info("default components enabled");
+            
+        this._componentManager.resetDefaultMetaComponents();
+        //read the default layer spec
+        if (docMeta.scaleSettings) {
+            docMeta.scaleSettings.forEach(function (spec) {
+
+                //make the spec as-expected for component manager
+
+                if (typeof spec.folder === "string") {
+                    spec.folder = [spec.folder];
+                }
+                if (!spec.file) {
+                    spec.file = "";
+                }
+
+                this._componentManager.addDefaultMetaComponent(spec);
+            }, this);
+        }
+    };
+    
+    /**
+     * Initialize all the components from each layer
+     * 
+     * @private
+     * @param {bool} resetLayerBounds whether this layers bounds need to get recalculated
+     * @return {Array} array of layer ID that were added
+     */
+    AssetManager.prototype._initComponents = function (resetLayerBounds) {
+        var layerIdsWithComponents = [];
+        
+        this._document.layers.visit(function (layer) {
+            // Don't visit the top-level LayerGroup
+            if (!layer.group) {
+                return;
+            }
+
+            var hasValidComponent = false;
+            
+            try {
+                this._componentManager.findAllComponents(layer).forEach(function (result) {
+                    var component = result.component;
+                    if (component) {
+                        try {
+                            if (resetLayerBounds) {
+                                component.needsLayerBoundsUpdate = true;
+                            }
+                            this._componentManager.addComponent(layer, component);
+                            hasValidComponent = true;
+                        } catch (ex) {
+                            this._errorManager.addError(layer, ex.message);
+                        }
+                    } else if (result.errors) {
+                        result.errors.forEach(function (error) {
+                            this._errorManager.addError(layer, error);
+                        }.bind(this));
+                    }
+                }, this);
+            } catch (ex) {
+                this._errorManager.addError(layer, ex.message);
+            }
+
+            if (hasValidComponent) {
+                layerIdsWithComponents.push(layer.id);
+            }
+        }.bind(this));
+        
+        return layerIdsWithComponents;
+    };
+    
+    /**
      * Initialize this AssetManager instance, completely resetting internal state
      * and re-rendering the components of all layers. This does NOT delete any
      * existing assets; for that @see AssetManager.prototype._cleanup.
@@ -214,44 +309,18 @@
         
         var layerIdsWithComponents = [],
             compComponents = [],
-            doc = this._document,
-            comps = doc._comps;
+            comps = this._document._comps,
+            docMeta = this._getDocumentMetaData();
         
-        this._document.layers.visit(function (layer) {
-            // Don't visit the top-level LayerGroup
-            if (!layer.group) {
-                return;
-            }
-
-            var hasValidComponent = false;
-
-            this._componentManager.findAllComponents(layer).forEach(function (result) {
-                var component = result.component;
-                if (component) {
-                    try {
-                        if (resetLayerBounds) {
-                            component.needsLayerBoundsUpdate = true;
-                        }
-                        this._componentManager.addComponent(layer, component);
-                        hasValidComponent = true;
-                    } catch (ex) {
-                        this._errorManager.addError(layer, ex.message);
-                    }
-                } else if (result.errors) {
-                    result.errors.forEach(function (error) {
-                        this._errorManager.addError(layer, error);
-                    }.bind(this));
-                }
-            }, this);
-
-            if (hasValidComponent) {
-                layerIdsWithComponents.push(layer.id);
-            }
-        }.bind(this));
+        if (docMeta && docMeta.metaEnabled) {
+            this._initDefaultMetaComponents(docMeta, resetLayerBounds);
+        }
+        
+        layerIdsWithComponents = this._initComponents(resetLayerBounds);
 
         if (comps) {
             comps.forEach(function (comp) {
-                this._addComponentsForComp(comp, doc, compComponents);
+                this._addComponentsForComp(comp, this._document, compComponents);
             }.bind(this));
         }
         
@@ -485,8 +554,9 @@
             this._fileManager.updateBasePath(this._document);
         }
 
-        if (change.resolution || change.bounds) {
-            this._reset(true);
+        if (change.resolution || change.bounds || change.generatorSettings) {
+            this._reset(!change.generatorSettings);
+            return;
         }
 
         if (change.comps) {

--- a/lib/componentmanager.js
+++ b/lib/componentmanager.js
@@ -24,11 +24,10 @@
 (function () {
     "use strict";
 
-    var path = require("path");
-
-    var ParserManager = require("./parsermanager");
-
-    var _componentIdCounter = 0;
+    var path = require("path"),
+        ParserManager = require("./parsermanager"),
+        META_PLUGIN_ID = "crema",
+        _componentIdCounter = 0;
 
     // FIXME: The relationship between basic components, default components and
     // derived components should be made explicit. It's kind of a mess now
@@ -45,9 +44,8 @@
         if (component.folder) {
             var folder = component.folder.concat([component.file]);
             return folder.join(path.sep);
-        } else {
-            return component.file;
         }
+        return component.file;
     }
 
     /**
@@ -99,11 +97,11 @@
         }
 
         if (def.hasOwnProperty("scale") ||
-            def.hasOwnProperty("width") ||
-            def.hasOwnProperty("height")) {
+                def.hasOwnProperty("width") ||
+                def.hasOwnProperty("height")) {
             if (!derived.hasOwnProperty("scale") &&
-                !derived.hasOwnProperty("width") &&
-                !derived.hasOwnProperty("height")) {
+                    !derived.hasOwnProperty("width") &&
+                    !derived.hasOwnProperty("height")) {
 
                 if (def.hasOwnProperty("scale")) {
                     derived.scale = def.scale;
@@ -137,13 +135,16 @@
      * 
      * @constructor
      */
-    function ComponentManager(generator, config) {
+    function ComponentManager(generator, config, logger, doc) {
         this._parserManager = new ParserManager(config);
+        this._document = doc;
+        this._config = config;
         this._allComponents = {};
         this._componentsForLayer = {};
         this._componentsForComp = {};
         this._paths = {};
         this._defaultLayerId = null;
+        this._metaDefaultComponents = [];
     }
 
     /**
@@ -151,6 +152,22 @@
      */
     ComponentManager.prototype._parserManager = null;
 
+    /**
+     * Generator config preferences
+     * @type {Object}
+     */
+    ComponentManager.prototype._config = null;
+    
+    /**
+     * @type {Document}
+     */
+    ComponentManager.prototype._document = null;
+    
+     /**
+     * The default components as set by meta-data
+     */
+    ComponentManager.prototype._metaDefaultComponents = null;
+    
     /**
      * The a set of components, keyed by component ID.
      * 
@@ -246,6 +263,28 @@
         this._componentsForLayer[layer.id][componentId] = true;
 
         return componentId;
+    };
+    
+    /**
+     * resets the default component IDs
+     */
+    ComponentManager.prototype.resetDefaultMetaComponents = function () {
+        this._metaDefaultComponents.forEach(function (component) {
+            delete this._allComponents[component.id];
+        }.bind(this));
+        this._metaDefaultComponents = [];
+    };
+
+    /**
+     * Add a defailt meta component object. These come from document level
+     * meta-data instead of a special "default" layer
+     */
+    ComponentManager.prototype.addDefaultMetaComponent = function (component) {
+        var componentId = this.getComponentId();
+        component.id = componentId;
+
+        this._metaDefaultComponents.push(component);
+        this._allComponents[componentId] = component;
     };
     
     /**
@@ -349,9 +388,8 @@
                 components[componentId] = component;
                 return components;
             }.bind(this), {});
-        } else {
-            return {};
         }
+        return {};
     };
     
     /**
@@ -368,9 +406,8 @@
                 components[componentId] = component;
                 return components;
             }.bind(this), {});
-        } else {
-            return {};
         }
+        return {};
     };
 
     /**
@@ -397,20 +434,26 @@
      * @return {Array.<Component>}
      */
     ComponentManager.prototype.getDerivedComponents = function (componentId) {
-        var component = this.getComponent(componentId);
+        var component = this.getComponent(componentId),
+            defaultComponents;
 
-        if (this._defaultLayerId === null) {
-            return [component];
+        if (!this._config["meta-data-driven"]) {
+            if (this._defaultLayerId === null) {
+                return [component];
+            }
+
+            if (component.default) {
+                return [];
+            }
+
+            var defaultComponentMap = this._componentsForLayer[this._defaultLayerId];
+            defaultComponents = Object.keys(defaultComponentMap)
+                .map(function (componentId) {
+                    return this.getComponent(componentId);
+                }, this);
+        } else {
+            defaultComponents = this._metaDefaultComponents;
         }
-
-        if (component.default) {
-            return [];
-        }
-
-        var defaultComponentMap = this._componentsForLayer[this._defaultLayerId],
-            defaultComponents = Object.keys(defaultComponentMap).map(function (componentId) {
-                return this.getComponent(componentId);
-            }, this);
 
         if (defaultComponents.length === 0) {
             return [component];
@@ -421,21 +464,9 @@
         });
     };
 
-    /**
-     * Extract all component-like objects from a given layer. Returns a list of
-     * items, each of which is either a component-like object or a list of analysis
-     * errors that should be reported back to the user. The component-like objects
-     * are only fully initialized after being added to a given component manager.
-     * 
-     * @see ComponentManager.prototype.addComponent
-     * @param {Layer} layer The layer from which to extract components
-     * @return {Array.<{errors: Array.<string>} | {component: Component}>}
-     */
-    ComponentManager.prototype.findAllComponents = function (layer) {
-        
-        var results,
-            components = [];
-
+    ComponentManager.prototype._findAllComponentsUsingLayerNames = function (layer) {
+        var components = [],
+            results;
         if (layer.name) {
             results = this._parserManager.analyzeLayerName(layer.name);
             results.forEach(function (result) {
@@ -451,6 +482,47 @@
             }, this);
         }
         return components;
+    };
+    
+    ComponentManager.prototype._findAllComponentsUsingMetaData = function (layer) {
+        var components = [],
+            layerMeta = layer._generatorSettings[META_PLUGIN_ID];
+        
+        if (layerMeta && layerMeta.json) {
+            layerMeta = JSON.parse(layerMeta.json);
+        }
+        
+        if (layerMeta && layerMeta.assetSettings) {
+            layerMeta.assetSettings.forEach(function (setting) {
+                
+                if (setting.file && setting.extension) {
+                    var result = this._parserManager.analyzeComponent(setting);
+                    if (result.errors.length > 0) {
+                        components.push({errors: result.errors});
+                    } else {
+                        components.push({component: result.component});
+                    }
+                }
+            }, this);
+        }
+        return components;
+    };
+    
+    /**
+     * Extract all component-like objects from a given layer. Returns a list of
+     * items, each of which is either a component-like object or a list of analysis
+     * errors that should be reported back to the user. The component-like objects
+     * are only fully initialized after being added to a given component manager.
+     * 
+     * @see ComponentManager.prototype.addComponent
+     * @param {Layer} layer The layer from which to extract components
+     * @return {Array.<{errors: Array.<string>} | {component: Component}>}
+     */
+    ComponentManager.prototype.findAllComponents = function (layer) {
+        if (!this._config["meta-data-driven"]) {
+            return this._findAllComponentsUsingLayerNames(layer);
+        }
+        return this._findAllComponentsUsingMetaData(layer);
     };
 
     module.exports = ComponentManager;

--- a/lib/parsermanager.js
+++ b/lib/parsermanager.js
@@ -216,14 +216,26 @@
             }];
         }
 
-        return components.map(function (component) {
-            this._normalizeComponent(component);
+        return components.map(this.analyzeComponent, this);
+    };
+    
+    /**
+     * Returns a list of errors encountered while analyzing that component.
+     * The component denotes a valid asset iff there are no analysis errors and
+     * the component contains either a "file" property (if it is a "basic"
+     * component that describes a single asset) or a "default" property (if it
+     * is default component that is used to derive non-basic components.)
+     *
+     * @param {Component} component
+     * @return {component: Component, errors: Array.<string>}
+     */
+    ParserManager.prototype.analyzeComponent = function (component) {
+        this._normalizeComponent(component);
 
-            return {
-                component: component,
-                errors: this._analyzeComponent(component)
-            };
-        }, this);
+        return {
+            component: component,
+            errors: this._analyzeComponent(component)
+        };
     };
 
     module.exports = ParserManager;

--- a/main.js
+++ b/main.js
@@ -270,6 +270,7 @@
         exports._renderManager = _renderManager;
         exports._stateManager = _stateManager;
         exports._assetManagers = _assetManagers;
+        exports._layerNameParse = require("./lib/parser").parse;
 
         _stateManager.on("enabled", _startAssetGeneration);
         _stateManager.on("disabled", _pauseAssetGeneration);


### PR DESCRIPTION
Controlled by a config option ‘meta-data-driven’

For development/testing add the generator.json config option "meta-data-test-menu-enabled" that enables 2 menus in File > Generate
1) "Apply meta-data to selection" adds hard-coded meta data to the selected layer and creates a global meta-data spec (2x and 0.5x)
2) "Layer syntax to meta-data" parses the selected layers and stores the result in meta-data.