### PR TITLE
Don't crash generator assets when there is no layer metadata.

### DIFF
--- a/lib/componentmanager.js
+++ b/lib/componentmanager.js
@@ -502,7 +502,7 @@
     
     ComponentManager.prototype._findAllComponentsUsingMetaData = function (layer) {
         var components = [],
-            layerMeta = layer._generatorSettings[META_PLUGIN_ID];
+            layerMeta = layer._generatorSettings && layer._generatorSettings[META_PLUGIN_ID];
         
         if (layerMeta && layerMeta.json) {
             layerMeta = JSON.parse(layerMeta.json);


### PR DESCRIPTION
The PSDs I try sometimes bring down generator assets because `layer._generatorSettings` is undefined.

@chrisbank Review please?