### PR TITLE
Added an absolute version of the move file method of FileManager

### DIFF
--- a/lib/asyncqueue.js
+++ b/lib/asyncqueue.js
@@ -111,11 +111,15 @@
             deferred = job.deferred;
 
         this._current = fn()
-            .fail(function (err) {
-                this.emit("error", err);
-            }.bind(this))
+            .then(
+                function (result) {
+                    deferred.resolve(result);
+                },
+                function (err) {
+                    this.emit("error", err);
+                    deferred.reject(err);
+                }.bind(this))
             .finally(function () {
-                deferred.resolve();
                 this._current = null;
 
                 if (!this._isPaused) {

--- a/lib/filemanager.js
+++ b/lib/filemanager.js
@@ -220,7 +220,7 @@
             }.bind(this));
     };
 
-   /**
+    /**
      * Remove the file or folder at the given full path. 
      *
      * @private
@@ -231,7 +231,7 @@
         return Q.ninvoke(fs, "remove", fullPath);
     };
 
-   /**
+    /**
      * Write or append data to the file at the given fullPath. Ensure that the
      * file at fullPath exists by creating the necessary subdirectories.
      *
@@ -324,7 +324,7 @@
      * 
      * @param {string} sourceFullPath
      * @param {string} targetRelativePath
-     * @return {Promise} Resolves once the operation is complete.
+     * @return {Promise.<string>} Resolves with the full target file path when complete
      */
     FileManager.prototype.moveFileInto = function (sourceFullPath, targetRelativePath) {
         return this._later(function () {
@@ -334,17 +334,36 @@
             }
 
             var targetFullPath = path.resolve(basePath, targetRelativePath);
-            return this._moveFileHelper(sourceFullPath, targetFullPath);
+            return this._moveFileHelper(sourceFullPath, targetFullPath)
+                .thenResolve(targetFullPath);
+        }.bind(this));
+    };
+
+    /**
+     * Move a file at a given absolute path into the base directory managed by this
+     * FileManager instance to the given relative path.
+     *
+     * @param {string} sourceFullPath
+     * @param {string} targetFullPath
+     * @return {Promise.<string>} Resolves with the full target file path when complete
+     */
+    FileManager.prototype.moveFileAbsolute = function (sourceFullPath, targetFullPath) {
+        return this._later(function () {
+            return this._moveFileHelper(sourceFullPath, targetFullPath)
+                .thenResolve(targetFullPath);
         }.bind(this));
     };
 
     /**
      * Move a file under the base directory managed by this FileManager instance
      * to the given relative path.
+     *
+     * FIXME This seems to be dead code, and possibly wrong 
+     * (sourceRelativePath is not used?)
      * 
      * @param {string} sourceRelativePath
      * @param {string} targetRelativePath
-     * @return {Promise} Resolves once the operation is complete.
+     * @return {Promise.<string>} Resolves with the full target file path when complete
      */
     FileManager.prototype.moveFileWithin = function (sourceRelativePath, targetRelativePath) {
         return this._later(function () {
@@ -353,7 +372,6 @@
                 throw new Error("Can't move file: no base path");
             }
 
-
             var sourceFullPath = path.resolve(basePath, targetRelativePath),
                 targetFullPath = path.resolve(basePath, targetRelativePath);
 
@@ -361,7 +379,8 @@
                 .then(function () {
                     var sourceDirectory = path.dirname(sourceFullPath);
                     this._cleanup(basePath, sourceDirectory);
-                }.bind(this));
+                }.bind(this))
+                .thenResolve(targetFullPath);
         }.bind(this));
     };
 

--- a/lib/filemanager.js
+++ b/lib/filemanager.js
@@ -355,36 +355,6 @@
     };
 
     /**
-     * Move a file under the base directory managed by this FileManager instance
-     * to the given relative path.
-     *
-     * FIXME This seems to be dead code, and possibly wrong 
-     * (sourceRelativePath is not used?)
-     * 
-     * @param {string} sourceRelativePath
-     * @param {string} targetRelativePath
-     * @return {Promise.<string>} Resolves with the full target file path when complete
-     */
-    FileManager.prototype.moveFileWithin = function (sourceRelativePath, targetRelativePath) {
-        return this._later(function () {
-            var basePath = this._basePath;
-            if (!basePath) {
-                throw new Error("Can't move file: no base path");
-            }
-
-            var sourceFullPath = path.resolve(basePath, targetRelativePath),
-                targetFullPath = path.resolve(basePath, targetRelativePath);
-
-            return this._moveFileHelper(sourceFullPath, targetFullPath)
-                .then(function () {
-                    var sourceDirectory = path.dirname(sourceFullPath);
-                    this._cleanup(basePath, sourceDirectory);
-                }.bind(this))
-                .thenResolve(targetFullPath);
-        }.bind(this));
-    };
-
-    /**
      * Remove a file at a given absolute path.
      * 
      * @param {string} fullPath


### PR DESCRIPTION
- Added targetPath as the resolved result of fileManager's `moveFileWithin` and `moveFileInto` methods
- Noted that `moveFileWithin` might be dead code
- Added a new `moveFileAbsolute` to support the Design Space export process
- Updated `asyncqueue` so that as jobs complete, the underlying deferred is resolved with *the return value*
- Updated `asyncqueue` so that as jobs error, the underlying deferred is rejected with that error