### PR TITLE
changes to optional use flite for image encoding

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -86,6 +86,10 @@
         if (config.hasOwnProperty("use-pngquant")) {
             this._usePngquant = !!config["use-pngquant"];
         }
+        
+        if (config.hasOwnProperty("use-flite")) {
+            this._useFlite = !!config["use-flite"];
+        }
 
         if (config.hasOwnProperty("webp-lossless")) {
             this._webpLossless = !!config["webp-lossless"];
@@ -148,6 +152,11 @@
      */
     BaseRenderer.prototype._usePngquant = true;
 
+    /**
+     * @type {boolean=}
+     */
+    BaseRenderer.prototype._useFlite = false;
+    
     /**
      * @type {boolean=}
      * Indicates whether webp assets should be compressed losslessly. By default,
@@ -1169,6 +1178,12 @@
                 
                 if (this._usePngquant !== undefined) {
                     settings.usePngquant = this._usePngquant;
+                }
+                
+                if (component.hasOwnProperty("useFlite")) {
+                    settings.useFlite = component.useFlite;
+                } else if (this._useFlite !== undefined) {
+                    settings.useFlite = this._useFlite;
                 }
 
                 if (this._webpLossless !== undefined) {


### PR DESCRIPTION
This adds the option to use the flitetranscoder support added to generator core. By default generate-assets does not use it. This can get override at a global level using a configuration json file with ```use-flite: true```and at the individual component level by plugins rendering components.