### PR TITLE
Add explicit useFlite handling for direct users of PixmapRenderer

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -549,6 +549,10 @@
         if (config.hasOwnProperty("interpolation-type")) {
             this._interpolationType = config["interpolation-type"];
         }
+
+        if (config.hasOwnProperty("use-flite")) {
+            this._useFlite = config["use-flite"];
+        }
     }
 
     util.inherits(PixmapRenderer, BaseRenderer);
@@ -1145,7 +1149,7 @@
             if (this._forceSmartPSDPixelScaling !== undefined) {
                 pixmapSettings.forceSmartPSDPixelScaling = this._forceSmartPSDPixelScaling;
             }
-            
+
             var fnHandlePixmap = function (pixmap) {
                 var padding = pixmapSettings.hasOwnProperty("getPadding") ?
                         pixmapSettings.getPadding(pixmap.width, pixmap.height) : undefined,
@@ -1173,6 +1177,10 @@
 
                 if (this._webpLossless !== undefined) {
                     settings.lossless = this._webpLossless;
+                }
+
+                if (this._useFlite !== undefined) {
+                    settings.useFlite = this._useFlite;
                 }
 
                 return {


### PR DESCRIPTION
This seems to be necessary for the generator-spaces plugin to inject the `use-flite` setting.  @chrisbank please take a look and let me know if I missed something.  I'm chalking it up to there being slightly different usage pattern between g-s and crema; perhaps the use of `renderer.renderToStream()` vs renderer.render()`? It is very possible you can convince me I'm doing it wrong.