### PR TITLE
options for faster DocumentManager instances

### DIFF
--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -65,13 +65,21 @@
      * @param {Generator} generator
      * @param {object} config
      * @param {Logger} logger
+     * @param {object*} options, runtime options:
+     *                    getDocumentInfoFlags: object, key documented at getDocumentInfo
+     *                    clearCacheOnChange: bool, removes the document from the cache on
+     *                          change instead of updating it and sending a change event
      */
-    function DocumentManager(generator, config, logger) {
+    function DocumentManager(generator, config, logger, options) {
         EventEmitter.call(this);
         
         this._generator = generator;
         this._config = config;
         this._logger = logger;
+        
+        options = options || {};
+        this._getDocumentInfoFlags = options.getDocumentInfoFlags;
+        this._clearCacheOnChange = options.clearCacheOnChange;
 
         this._documents = {};
         this._documentDeferreds = {};
@@ -175,6 +183,26 @@
      * @type {?number}
      */
     DocumentManager.prototype._activeDocumentId = null;
+    
+    /**
+     * Flags to pass into the main call to getDocumentInfo
+     *
+     * @private
+     * @type {object}
+     */
+    DocumentManager.prototype._getDocumentInfoFlags = null;
+    
+    
+    /**
+     * Controls cached document management. The default is to keep the documents in sync
+     * on each change event. You can optional just have the document removed from the 
+     * cache on change so the next call to getDocument() will result in a full call to
+     * getDocumentInfo.
+     *
+     * @private
+     * @type {boolean}
+     */
+    DocumentManager.prototype._clearCacheOnChange = false;
 
     /**
      * Asynchronously create a new Document object using the full document
@@ -185,10 +213,20 @@
      * @return {Promise.<Document>} A promis that resolves with a new Document object for the given ID.
      */
     DocumentManager.prototype._getEntireDocument = function (id) {
-        return this._generator.getDocumentInfo(id).then(function (raw) {
-            // this._logger.debug(JSON.stringify(raw, null, "  "));
+        return this._generator.getDocumentInfo(id, this._getDocumentInfoFlags).then(function (raw) {
             return new Document(this._generator, this._config, this._logger, raw);
         }.bind(this));
+    };
+    
+    /**
+     * Removes the cached instance of the document 
+     * 
+     * @private
+     * @param {!number} id The ID of the Document to remove
+     */
+    DocumentManager.prototype._removeDocument = function (id) {
+        delete this._documents[id];
+        delete this._documentChanges[id];
     };
 
     /**
@@ -206,9 +244,8 @@
         this._getEntireDocument(id).done(function (document) {
             // Dispose of this document reference when the document is closed in Photoshop
             document.on("closed", function () {
-                delete this._documents[id];
-                delete this._documentChanges[id];
-
+                this._removeDocument(id);
+                
                 if (this._documentDeferreds.hasOwnProperty(id)) {
                     this._documentDeferreds[id].reject();
                     delete this._documentDeferreds[id];
@@ -475,6 +512,12 @@
 
         // ignore changes for document IDs until a client calls getDocument
         if (!this._documentDeferreds.hasOwnProperty(id) && !this._documents.hasOwnProperty(id)) {
+            return;
+        }
+        
+        // clear and leave if that option was set
+        if (this._clearCacheOnChange) {
+            this._removeDocument(id);
             return;
         }
 


### PR DESCRIPTION
This adds two options to speed up captive uses if the Document Manager. 

The first is the ability to specify what flags to pass to getDocumentInfo. In particular the `getTextStyles: false` will greatly speed up the getDocumentInfo call if you don't need to use text styles. 

The other is an option to clear the document managers document cache on change instead of trying to keep the cache up to date. This means the next call of getDocument() is called after an edit will call getDocumentInfo, but it keeps PS from doing a lot of extra work on each edit. 