### PR TITLE
include scale when calculating maxBounds

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -194,15 +194,79 @@
     BaseRenderer.prototype._expandMaxDimensions = false;
 
     /**
-     * Given a bounds, determines the max dimenesions to return the pixmap as.
+     * Return maximum pixels allosed
+     * 
+     * Node.js has a default memory limit of 512MB on 32-bit machines and 1024MB on 64-bit machines.
+     * It was empirically determined that a 10k x 10k (100M pixel image) uses ~580MB of memory in an IPC-connected
+     * generator. We'll use that value for 64-bit machines and 5k x 5k (25M pixel image) for 32-bit machines, to be
+     * conservative.
+     *
+     * NOTE: Do not use this from CEP. process.arch returns whether CEP is 32-bit or not instead of whether the
+     * machine is 32-bit or not.
+     *
+     * TODO: When we change generator to a streaming implementation, we shouldn't be limited by memory anymore.
+     * 
+     * @return {number}
+     */
+    BaseRenderer.prototype._getMaxPixels = function () {
+        return (process.arch === "x64" ? 100 : 25) * 1000 * 1000;
+    };
+
+    /**
+     * Return safe scales for X & Y maintaining aspect ratio
+     *
+     * @param {Bounds} bounds Image size
+     * @param {number} scaleX Horizontal scale
+     * @param {number} scaleY Vertical scale
+     * @return {Object} { scaleX:{number}, scaleY:{number} }
+     */
+    BaseRenderer.prototype._validateMaxScales = function (bounds, scaleX, scaleY) {
+        var maxPixels = this._getMaxPixels(),
+            scaleFactor = maxPixels / (Math.ceil(bounds.width() * scaleX) * Math.ceil(bounds.height() * scaleY));
+
+        if (scaleFactor < 1) {
+            // Need to scale down
+            scaleFactor = Math.sqrt(scaleFactor);
+            return {
+                scaleX: this._roundDown(scaleFactor * scaleX, 10000),
+                scaleY: this._roundDown(scaleFactor * scaleY, 10000)
+            };
+        }
+
+        // Scales are safe
+        return {
+            scaleX: scaleX,
+            scaleY: scaleY
+        };
+    };
+
+    /**
+     * Round number down to specified decimal places
+     *
+     * @param {number} value Value
+     * @param {number} placeInTens 10, 100, 1000, etc.
+     * @return {number} Rounded number
+     */
+    BaseRenderer.prototype._roundDown = function (value, placeInTens) {
+        return Math.floor(value * placeInTens) / placeInTens;
+    };
+
+    /**
+     * Given a bounds, determines the max dimensions to return the pixmap as.
      * Either expand to allow all dimensions or have a fixed limit base on a config flag
      *
      * @param {Bounds} bounds
+     * @param {number} scaleX
+     * @param {number} scaleY
      * @return {number}
      */
-    BaseRenderer.prototype._getPixmapMaxDimensions = function (bounds) {
+    BaseRenderer.prototype._getPixmapMaxDimensions = function (bounds, scaleX, scaleY) {
         if (this._expandMaxDimensions) {
-            var largestDimension = Math.max(bounds.width(), bounds.height());
+            scaleX = scaleX || 1;
+            scaleY = scaleY || scaleX;
+            var safeScale = this._validateMaxScales(bounds, scaleX, scaleY);
+            var largestDimension = Math.round(Math.max(bounds.width() * safeScale.scaleX,
+                                                       bounds.height() * safeScale.scaleY));
             return Math.max(MAX_STATIC_DIMENSION, largestDimension + ADDITONAL_POSSIBLE_DIMENSION);
         }
         return MAX_STATIC_DIMENSION;
@@ -661,10 +725,12 @@
             resultDeferred = Q.defer(),
             boundsAcquiredPromise,
             pixmapParams,
-            boundsResult;
+            boundsResult,
+            scaleX = component.scaleX || component.scale || 1,
+            scaleY = component.scaleY || component.scale || 1;
         
         if (layer) {
-            maxAcquireDimension = this._getPixmapMaxDimensions(layer.bounds);
+            maxAcquireDimension = this._getPixmapMaxDimensions(layer.bounds, scaleX, scaleY);
             boundsAcquiredPromise = layer.getExactBounds(cache, maxAcquireDimension).then(function (exactBounds) {
                 boundsResult = {
                     exactBounds: exactBounds,
@@ -673,7 +739,7 @@
                 return boundsResult;
             });
         } else {
-            maxAcquireDimension = this._getPixmapMaxDimensions(doc.bounds);
+            maxAcquireDimension = this._getPixmapMaxDimensions(doc.bounds, scaleX, scaleY);
             boundsAcquiredPromise = doc.getExactBounds(layerCompId, maxAcquireDimension).then(function (exactBounds) {
                 boundsResult = {
                     exactBounds: exactBounds,
@@ -758,7 +824,9 @@
             
             pixmapParams = this._generator.getPixmapParams(scaleSettings, staticBounds,
                     visibleBounds, paddedBounds, clipToBounds);
-            pixmapParams.maxDimension = this._getPixmapMaxDimensions(visibleBounds);
+            pixmapParams.maxDimension = this._getPixmapMaxDimensions(visibleBounds,
+                                                                     scaleSettings.scaleX,
+                                                                     scaleSettings.scaleY);
             
             resultDeferred.resolve(pixmapParams);
         }.bind(this)).fail(resultDeferred.reject);
@@ -777,10 +845,7 @@
      *      expectedHeight: number, getPadding: function (number, number): number }}
      */
     PixmapRenderer.prototype._getSettingsWithApproximateBounds = function (component) {
-        var scalar = component.scale;
-        if (!scalar) {
-            scalar = 1;
-        }
+        var scalar = component.scale || 1;
 
         var inputRect,
             paddedBounds,
@@ -832,7 +897,7 @@
             scaleY: scalar
         };
         var pixmapParams = this._generator.getPixmapParams(settings, inputRect, inputRect, paddedBounds, clipToBounds);
-        pixmapParams.maxDimension = this._getPixmapMaxDimensions(inputRect);
+        pixmapParams.maxDimension = this._getPixmapMaxDimensions(inputRect, scalar, scalar);
             
         return pixmapParams;
     };


### PR DESCRIPTION
when calculating the max size to export an image, need to include the scale

Here is the bug number : https://watsonexp.corp.adobe.com/#bug=4065468