### PR TITLE
Updated zero bounds check to include whole document. Also updated Content Bounds calculations

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1129,19 +1129,19 @@
      * @private
      * @param {!Component} component 
      */
-    PixmapRenderer.prototype._componentHasZeroBoundsLayer = function (component) {
-        var layerHasZeroBounds = function (layer) {
-            return layer && (!layer.bounds || (layer.bounds.top === 0 &&
-                                                layer.bounds.bottom === 0 &&
-                                                layer.bounds.left === 0 &&
-                                                layer.bounds.right === 0));
+    PixmapRenderer.prototype._componentHasZeroBounds = function (component) {
+        var hasZeroBounds = function (bounds) {
+            return !bounds || (bounds.top === 0 &&
+                                bounds.bottom === 0 &&
+                                bounds.left === 0 &&
+                                bounds.right === 0);
         };
         
         if (component.layer) {
-            return component.layer.visit(layerHasZeroBounds);
+            return hasZeroBounds(component.layer);
         }
         
-        return component.document.layers.visit(layerHasZeroBounds);
+        return hasZeroBounds(this._getContentBounds(component.document.layers));
     };
         
     /**
@@ -1175,13 +1175,13 @@
             hasMask = layer && layer.getTotalMaskBounds(),
             includeAncestorMasks = layer && this._includeAncestorMasks,
             hasEffects = this._componentHasLayerEffects(component),
-            hasZeroBoundsLayer = this._componentHasZeroBoundsLayer(component);
+            hasZeroBounds = this._componentHasZeroBounds(component);
         
         //hasComplexTransform is the only part of this test that affects layerComp
         if (hasComplexTransform ||
             hasMask ||
             hasEffects ||
-            hasZeroBoundsLayer ||
+            hasZeroBounds ||
             isClipped ||
             includeAncestorMasks) {
             //do the more expensive check

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1116,6 +1116,26 @@
         
         return component.document.layers.visit(layerHasEffects);
     };
+
+    /**
+     * Check if the document returns empty bounds.
+     * 
+     * @private
+     * @param {Document} document incoming document where empty layers will be searched for.
+     * @return {boolean}
+     */
+    PixmapRenderer.prototype._documentHasZeroBounds = function (document) {
+
+        var docBounds = this._getContentBounds(document.layers, true);
+        if (docBounds.top === 0 &&
+            docBounds.left === 0 &&
+            docBounds.bottom === 0 &&
+            docBounds.right === 0) {
+            return true;
+        } else {
+            return false;
+        }
+    };
     
     
     /**
@@ -1138,10 +1158,12 @@
         // 4. The "include-ancestor-masks" config option is NOT set
         // 5. The layer has non-zero bounds. Sometimes they aren't computed and set to all 0's
         // 6. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
+        // 7. The document has non-zero bounds. Sometimes document bounds aren't computed returns all 0's.
         var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
                 component.hasOwnProperty("width") || component.hasOwnProperty("height"),
             canvasDimensionsScale = 1,
             layer = component.layer,
+            document = component.document,
             layerComp = component.comp,
             settingsPromise,
             resultPromise,
@@ -1152,10 +1174,17 @@
             hasZeroBounds = layer && (!layer.bounds || (layer.bounds.top === 0 &&
                                                         layer.bounds.bottom === 0 &&
                                                         layer.bounds.left === 0 &&
-                                                        layer.bounds.right === 0));
+                                                        layer.bounds.right === 0)),
+            documentHasZeroBounds = document && this._documentHasZeroBounds(document);
         
         //hasComplexTransform is the only part of this test that affects layerComp
-        if (hasComplexTransform || hasMask || hasEffects || hasZeroBounds || isClipped || includeAcestorMasks) {
+        if (hasComplexTransform ||
+            hasMask ||
+            hasEffects ||
+            hasZeroBounds ||
+            isClipped ||
+            includeAcestorMasks ||
+            documentHasZeroBounds) {
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1138,7 +1138,7 @@
         };
         
         if (component.layer) {
-            return hasZeroBounds(component.layer);
+            return hasZeroBounds(component.layer.bounds);
         }
         
         return hasZeroBounds(this._getContentBounds(component.document.layers));

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -682,8 +682,14 @@
         
         //explicitly checked for visible === false. If the user can toggle the visibilty than
         //the value is always true or false. If they can't then the visible value is null or 
-        //undefined
-        if (layer.visible === false || layer.clipped || layer.type === "adjustmentLayer") {
+        //undefined. Added test for checking the stroke style, if both fill and stroke is set
+        //to false then essentially layer has no content.
+        if (layer.visible === false ||
+            layer.clipped ||
+            layer.type === "adjustmentLayer" ||
+            (layer.strokeStyle &&
+            layer.strokeStyle.fillEnabled === false &&
+            layer.strokeStyle.strokeEnabled === false)) {
             return new Bounds({top: 0, left: 0, bottom: 0, right: 0});
         }
         
@@ -1118,26 +1124,26 @@
     };
 
     /**
-     * Check if the document returns empty bounds.
+     * checks to see if there component has any layer with zero bounds.
      * 
      * @private
-     * @param {Document} document incoming document where empty layers will be searched for.
-     * @return {boolean}
+     * @param {!Component} component 
      */
-    PixmapRenderer.prototype._documentHasZeroBounds = function (document) {
-
-        var docBounds = this._getContentBounds(document.layers, true);
-        if (docBounds.top === 0 &&
-            docBounds.left === 0 &&
-            docBounds.bottom === 0 &&
-            docBounds.right === 0) {
-            return true;
-        } else {
-            return false;
+    PixmapRenderer.prototype._componentHasZeroBoundsLayer = function (component) {
+        var layerHasZeroBounds = function (layer) {
+            return layer && (!layer.bounds || (layer.bounds.top === 0 &&
+                                                layer.bounds.bottom === 0 &&
+                                                layer.bounds.left === 0 &&
+                                                layer.bounds.right === 0));
+        };
+        
+        if (component.layer) {
+            return component.layer.visit(layerHasZeroBounds);
         }
+        
+        return component.document.layers.visit(layerHasZeroBounds);
     };
-    
-    
+        
     /**
      * Get pixmap data for the given component.
      * 
@@ -1156,35 +1162,28 @@
         // 2. The layer does not have an enabled mask
         // 3. The layer does not have any enabled layer effects
         // 4. The "include-ancestor-masks" config option is NOT set
-        // 5. The layer has non-zero bounds. Sometimes they aren't computed and set to all 0's
+        // 5. None of the layers has zero bounds. Sometimes they aren't computed and set to all 0's
         // 6. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
-        // 7. The document has non-zero bounds. Sometimes document bounds aren't computed returns all 0's.
         var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
                 component.hasOwnProperty("width") || component.hasOwnProperty("height"),
             canvasDimensionsScale = 1,
             layer = component.layer,
-            document = component.document,
             layerComp = component.comp,
             settingsPromise,
             resultPromise,
             isClipped = layer && layer.clipped,
             hasMask = layer && layer.getTotalMaskBounds(),
-            includeAcestorMasks = layer && this._includeAncestorMasks,
+            includeAncestorMasks = layer && this._includeAncestorMasks,
             hasEffects = this._componentHasLayerEffects(component),
-            hasZeroBounds = layer && (!layer.bounds || (layer.bounds.top === 0 &&
-                                                        layer.bounds.bottom === 0 &&
-                                                        layer.bounds.left === 0 &&
-                                                        layer.bounds.right === 0)),
-            documentHasZeroBounds = document && this._documentHasZeroBounds(document);
+            hasZeroBoundsLayer = this._componentHasZeroBoundsLayer(component);
         
         //hasComplexTransform is the only part of this test that affects layerComp
         if (hasComplexTransform ||
             hasMask ||
             hasEffects ||
-            hasZeroBounds ||
+            hasZeroBoundsLayer ||
             isClipped ||
-            includeAcestorMasks ||
-            documentHasZeroBounds) {
+            includeAncestorMasks) {
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {


### PR DESCRIPTION
Bug reference:
#4025261: Export As shows that document is empty when it isn't (create new file and paste)
#4075363: Asset is not clipped to document bound (file with empty layer that goes outside of doc bound + layer mask)

- Need to check for zero bounds for the whole document. If whole document returns zero bounds it's recommended to double check the correctness of documentInfo.
- When you have a shape layer with no-fill and no stroke essentially it's an empty layer. Handling it in the content bounds calculations.