### PR TITLE
Updating zero bound check to include document level check

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1116,8 +1116,28 @@
         
         return component.document.layers.visit(layerHasEffects);
     };
-    
-    
+
+    /**
+     * checks to see if there component has any layer with zero bounds.
+     * 
+     * @private
+     * @param {!Component} component 
+     */
+    PixmapRenderer.prototype._componentHasZeroBounds = function (component) {
+        var hasZeroBounds = function (bounds) {
+            return !bounds || (bounds.top === 0 &&
+                                bounds.bottom === 0 &&
+                                bounds.left === 0 &&
+                                bounds.right === 0);
+        };
+        
+        if (component.layer) {
+            return hasZeroBounds(component.layer.bounds);
+        }
+        
+        return hasZeroBounds(this._getContentBounds(component.document.layers));
+    };
+        
     /**
      * Get pixmap data for the given component.
      * 
@@ -1136,7 +1156,7 @@
         // 2. The layer does not have an enabled mask
         // 3. The layer does not have any enabled layer effects
         // 4. The "include-ancestor-masks" config option is NOT set
-        // 5. The layer has non-zero bounds. Sometimes they aren't computed and set to all 0's
+        // 5. None of the layers has zero bounds. Sometimes they aren't computed and set to all 0's
         // 6. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
         var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
                 component.hasOwnProperty("width") || component.hasOwnProperty("height"),
@@ -1147,15 +1167,17 @@
             resultPromise,
             isClipped = layer && layer.clipped,
             hasMask = layer && layer.getTotalMaskBounds(),
-            includeAcestorMasks = layer && this._includeAncestorMasks,
+            includeAncestorMasks = layer && this._includeAncestorMasks,
             hasEffects = this._componentHasLayerEffects(component),
-            hasZeroBounds = layer && (!layer.bounds || (layer.bounds.top === 0 &&
-                                                        layer.bounds.bottom === 0 &&
-                                                        layer.bounds.left === 0 &&
-                                                        layer.bounds.right === 0));
+            hasZeroBounds = this._componentHasZeroBounds(component);
         
         //hasComplexTransform is the only part of this test that affects layerComp
-        if (hasComplexTransform || hasMask || hasEffects || hasZeroBounds || isClipped || includeAcestorMasks) {
+        if (hasComplexTransform ||
+            hasMask ||
+            hasEffects ||
+            hasZeroBounds ||
+            isClipped ||
+            includeAncestorMasks) {
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {


### PR DESCRIPTION
Updating zero bound check to include document level check also. In some cases docInfo is not updated and it ends up getting zero bounds at the doucment level also. In such a case it's better to get bounds using  `_getSettingsWithExactBounds`

This was squashed and split off of PR #369, so see conversation there.
