### PR TITLE
don't scale the limit for the starting dimensions

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -725,60 +725,51 @@
             resultDeferred = Q.defer(),
             boundsAcquiredPromise,
             pixmapParams,
-            boundsResult,
-            scaleX = component.scaleX || component.scale || 1,
-            scaleY = component.scaleY || component.scale || 1;
+            maskBounds,
+            staticBounds,
+            canvasBounds;
         
         if (layer) {
-            maxAcquireDimension = this._getPixmapMaxDimensions(layer.bounds, scaleX, scaleY);
+            if (layer.artboard) {
+                //pixmap from PS is automatically clipped to artboard. Apply that here so we
+                //know what the expected results are
+                staticBounds = this._getContentBounds(layer, true).intersect(layer.artboard);
+                canvasBounds = layer.artboard;
+            } else {
+                maskBounds = layer.getTotalMaskBounds();
+                staticBounds  = new Bounds(this._generator.getDeepBounds(layer));
+            }
+        } else /* if layer comp or full documentation */ {
+            canvasBounds = component.document.bounds;
+            staticBounds = this._getContentBounds(component.document.layers, false);
+        }
+        
+        //Get the max unscaled bounds because this request is for the current dimensions from which the 
+        //final scaled dimensions are calculated from
+        maxAcquireDimension = this._getPixmapMaxDimensions(staticBounds);
+        
+        if (layer) {
             boundsAcquiredPromise = layer.getExactBounds(cache, maxAcquireDimension).then(function (exactBounds) {
-                boundsResult = {
-                    exactBounds: exactBounds,
-                    maskBounds: undefined
-                };
-                return boundsResult;
+                return { exactBounds: exactBounds };
             });
         } else {
-            maxAcquireDimension = this._getPixmapMaxDimensions(doc.bounds, scaleX, scaleY);
             boundsAcquiredPromise = doc.getExactBounds(layerCompId, maxAcquireDimension).then(function (exactBounds) {
-                boundsResult = {
-                    exactBounds: exactBounds,
-                    maskBounds: undefined
-                };
-                return boundsResult;
+                return { exactBounds: exactBounds };
             });
         }
         
         boundsAcquiredPromise.then(function (bndsIn) {
 
             var exactBounds = bndsIn.exactBounds,
-                maskBounds = bndsIn.maskBounds,
-                staticBounds,
                 scaleSettings,
                 visibleBounds,
                 paddedBounds,
-                canvasBounds,
                 clipToBounds;
             
             if (exactBounds.right <= exactBounds.left || exactBounds.bottom <= exactBounds.top) {
                 var error = new Error("Refusing to render pixmap with zero bounds.");
                 error.zeroBoundsError = true;
                 throw error;
-            }
-
-            if (layer) {
-                if (layer.artboard) {
-                    //pixmap from PS is automatically clipped to artboard. Apply that here so we
-                    //know what the expected results are
-                    staticBounds = this._getContentBounds(layer, true).intersect(layer.artboard);
-                    canvasBounds = layer.artboard;
-                } else {
-                    maskBounds = layer.getTotalMaskBounds();
-                    staticBounds  = new Bounds(this._generator.getDeepBounds(layer));
-                }
-            } else /* if layer comp or full documentation */ {
-                canvasBounds = component.document.bounds;
-                staticBounds = this._getContentBounds(component.document.layers, false).expandToIntegers();
             }
             
             if (this._clipAllImagesToDocumentBounds) {
@@ -859,11 +850,11 @@
                 inputRect = this._getContentBounds(layer, true).intersect(layer.artboard);
                 paddedBounds = this._safeUnionBounds(inputRect, layer.artboard);
             } else {
-                inputRect = layer.bounds.expandToIntegers();
+                inputRect = layer.bounds;
                 paddedBounds = inputRect;
             }
         } else { // layer comp
-            inputRect = this._getContentBounds(component.document.layers, false).expandToIntegers();
+            inputRect = this._getContentBounds(component.document.layers, false);
             paddedBounds = component.document.bounds.union(inputRect);
         }
 
@@ -884,7 +875,7 @@
         }
         
         if (clipToBounds) {
-            var clippedBounds = inputRect.intersect(clipToBounds);
+            var clippedBounds = inputRect.expandToIntegers().intersect(clipToBounds);
             if (clippedBounds.right <= clippedBounds.left || clippedBounds.bottom <= clippedBounds.top) {
                 var err = new Error("Refusing to render pixmap with bounds completely clipped.");
                 err.outsideDocumentBoundsError = true;


### PR DESCRIPTION
also preserve float values as long as possible

#3975340 Export whole document/scaled: testfile is exported incorrectly (some layers are not clipped to doc bound; areas outside of doc canvas are in the asset and only half of actual image is in asset)