### PR TITLE
Adding check for layers with stroke style of no-fill and no-stroke. E…

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -682,8 +682,14 @@
         
         //explicitly checked for visible === false. If the user can toggle the visibilty than
         //the value is always true or false. If they can't then the visible value is null or 
-        //undefined
-        if (layer.visible === false || layer.clipped || layer.type === "adjustmentLayer") {
+        //undefined. Added test for checking the stroke style, if both fill and stroke is set
+        //to false then essentially layer has no content.
+        if (layer.visible === false ||
+            layer.clipped ||
+            layer.type === "adjustmentLayer" ||
+            (layer.strokeStyle &&
+            layer.strokeStyle.fillEnabled === false &&
+            layer.strokeStyle.strokeEnabled === false)) {
             return new Bounds({top: 0, left: 0, bottom: 0, right: 0});
         }
         


### PR DESCRIPTION
…ssentially such layer has no visible content and should be considered as non-visible layer.

This fixes a bug where documents does not clip properly if such a kind of layer is present.