### PR TITLE
use _getSettingsWithExactBounds in fewer cases

### DIFF
--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -539,6 +539,16 @@
     };
 
     /**
+     * Clear the passed doc id if it is in _documentDeferreds.
+     */
+    DocumentManager.prototype.clearDeferred = function (id) {
+        if (this._documentDeferreds.hasOwnProperty(id)) {
+            this._documentDeferreds[id].reject();
+            delete this._documentDeferreds[id];
+        }
+    };
+
+    /**
      * Asynchonously request an up-to-date Document object for the given document ID.
      *
      * @param {!number} id The document ID

--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -539,16 +539,6 @@
     };
 
     /**
-     * Clear the passed doc id if it is in _documentDeferreds.
-     */
-    DocumentManager.prototype.clearDeferred = function (id) {
-        if (this._documentDeferreds.hasOwnProperty(id)) {
-            this._documentDeferreds[id].reject();
-            delete this._documentDeferreds[id];
-        }
-    };
-
-    /**
      * Asynchonously request an up-to-date Document object for the given document ID.
      *
      * @param {!number} id The document ID

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -731,60 +731,51 @@
             resultDeferred = Q.defer(),
             boundsAcquiredPromise,
             pixmapParams,
-            boundsResult,
-            scaleX = component.scaleX || component.scale || 1,
-            scaleY = component.scaleY || component.scale || 1;
+            maskBounds,
+            staticBounds,
+            canvasBounds;
         
         if (layer) {
-            maxAcquireDimension = this._getPixmapMaxDimensions(layer.bounds, scaleX, scaleY);
+            if (layer.artboard) {
+                //pixmap from PS is automatically clipped to artboard. Apply that here so we
+                //know what the expected results are
+                staticBounds = this._getContentBounds(layer, true).intersect(layer.artboard);
+                canvasBounds = layer.artboard;
+            } else {
+                maskBounds = layer.getTotalMaskBounds();
+                staticBounds  = new Bounds(this._generator.getDeepBounds(layer));
+            }
+        } else /* if layer comp or full documentation */ {
+            canvasBounds = component.document.bounds;
+            staticBounds = this._getContentBounds(component.document.layers, false);
+        }
+        
+        //Get the max unscaled bounds because this request is for the current dimensions from which the 
+        //final scaled dimensions are calculated from
+        maxAcquireDimension = this._getPixmapMaxDimensions(staticBounds);
+        
+        if (layer) {
             boundsAcquiredPromise = layer.getExactBounds(cache, maxAcquireDimension).then(function (exactBounds) {
-                boundsResult = {
-                    exactBounds: exactBounds,
-                    maskBounds: undefined
-                };
-                return boundsResult;
+                return { exactBounds: exactBounds };
             });
         } else {
-            maxAcquireDimension = this._getPixmapMaxDimensions(doc.bounds, scaleX, scaleY);
             boundsAcquiredPromise = doc.getExactBounds(layerCompId, maxAcquireDimension).then(function (exactBounds) {
-                boundsResult = {
-                    exactBounds: exactBounds,
-                    maskBounds: undefined
-                };
-                return boundsResult;
+                return { exactBounds: exactBounds };
             });
         }
         
         boundsAcquiredPromise.then(function (bndsIn) {
 
             var exactBounds = bndsIn.exactBounds,
-                maskBounds = bndsIn.maskBounds,
-                staticBounds,
                 scaleSettings,
                 visibleBounds,
                 paddedBounds,
-                canvasBounds,
                 clipToBounds;
             
             if (exactBounds.right <= exactBounds.left || exactBounds.bottom <= exactBounds.top) {
                 var error = new Error("Refusing to render pixmap with zero bounds.");
                 error.zeroBoundsError = true;
                 throw error;
-            }
-
-            if (layer) {
-                if (layer.artboard) {
-                    //pixmap from PS is automatically clipped to artboard. Apply that here so we
-                    //know what the expected results are
-                    staticBounds = this._getContentBounds(layer, true).intersect(layer.artboard);
-                    canvasBounds = layer.artboard;
-                } else {
-                    maskBounds = layer.getTotalMaskBounds();
-                    staticBounds  = new Bounds(this._generator.getDeepBounds(layer));
-                }
-            } else /* if layer comp or full documentation */ {
-                canvasBounds = component.document.bounds;
-                staticBounds = this._getContentBounds(component.document.layers, false).expandToIntegers();
             }
             
             if (this._clipAllImagesToDocumentBounds) {
@@ -865,11 +856,11 @@
                 inputRect = this._getContentBounds(layer, true).intersect(layer.artboard);
                 paddedBounds = this._safeUnionBounds(inputRect, layer.artboard);
             } else {
-                inputRect = layer.bounds.expandToIntegers();
+                inputRect = layer.bounds;
                 paddedBounds = inputRect;
             }
         } else { // layer comp
-            inputRect = this._getContentBounds(component.document.layers, false).expandToIntegers();
+            inputRect = this._getContentBounds(component.document.layers, false);
             paddedBounds = component.document.bounds.union(inputRect);
         }
 
@@ -890,7 +881,7 @@
         }
         
         if (clipToBounds) {
-            var clippedBounds = inputRect.intersect(clipToBounds);
+            var clippedBounds = inputRect.expandToIntegers().intersect(clipToBounds);
             if (clippedBounds.right <= clippedBounds.left || clippedBounds.bottom <= clippedBounds.top) {
                 var err = new Error("Refusing to render pixmap with bounds completely clipped.");
                 err.outsideDocumentBoundsError = true;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1106,20 +1106,48 @@
     };
     
     /**
-     * checks to see if there is any part of the component that might extend due to layer effects
+     * Checks to see if there is any part of the component that might extend due to layer effects.
+     * Limit to a) layer effects that can actually enlarge a layer, and b) layers which, including
+     * their effects, touch the edge of the relevant container (document or artboard).
+     * (Mostly, we care about layers crossing the edges of the container, but in the case of
+     * a layerGroup, its bounds already account for the child layers with effects.)
      * 
      * @private
      * @param {!Component} component 
      */
     PixmapRenderer.prototype._componentHasLayerEffects = function (component) {
+        var componentBounds;
+
         var layerHasEffects = function (layer) {
-            return layer && layer.layerEffects && layer.layerEffects.isEnabled();
+            if (!layer || layer.visible === false || layer.group && layer.group.visible === false) {
+                return false;
+            }
+            var hasEffect = layer.layerEffects && (
+                (layer.layerEffects.bevelEmboss && layer.layerEffects.bevelEmboss.enabled) ||
+                (layer.layerEffects.dropShadow && layer.layerEffects.dropShadow.enabled) ||
+                (layer.layerEffects.outerGlow && layer.layerEffects.outerGlow.enabled) ||
+                (layer.layerEffects.frameFX && layer.layerEffects.enabled));
+            
+            if (hasEffect) {
+                if ((layer.boundsWithFX.left <= componentBounds.left) ||
+                    (layer.boundsWithFX.right >= componentBounds.right) ||
+                    (layer.boundsWithFX.bottom >= componentBounds.bottom) ||
+                    (layer.boundsWithFX.top <= componentBounds.top)) {
+                    
+                    return true;
+                }
+
+            } else {
+                return false;
+            }
         };
         
         if (component.layer) {
+            componentBounds = component.layer.bounds;
             return component.layer.visit(layerHasEffects);
         }
         
+        componentBounds = component.document.bounds;
         return component.document.layers.visit(layerHasEffects);
     };
 
@@ -1164,10 +1192,12 @@
         // 4. The "include-ancestor-masks" config option is NOT set
         // 5. None of the layers has zero bounds. Sometimes they aren't computed and set to all 0's
         // 6. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
-        var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
-                component.hasOwnProperty("width") || component.hasOwnProperty("height"),
+        var layer = component.layer,
+            hasComplexTransform = layer &&
+                ((component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
+                  component.hasOwnProperty("width") ||
+                  component.hasOwnProperty("height")),
             canvasDimensionsScale = 1,
-            layer = component.layer,
             layerComp = component.comp,
             settingsPromise,
             resultPromise,
@@ -1177,13 +1207,13 @@
             hasEffects = this._componentHasLayerEffects(component),
             hasZeroBounds = this._componentHasZeroBounds(component);
         
-        //hasComplexTransform is the only part of this test that affects layerComp
         if (hasComplexTransform ||
             hasMask ||
             hasEffects ||
             hasZeroBounds ||
             isClipped ||
             includeAncestorMasks) {
+
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,9 +13,9 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "jsonfile": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "jsonfile@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
         },
         "rimraf": {
           "version": "2.4.3",
@@ -55,9 +55,9 @@
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.2.0",
+                          "version": "0.2.1",
                           "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
@@ -99,7 +99,7 @@
     "svgobjectmodelgenerator": {
       "version": "0.6.0",
       "from": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#release-0.6",
-      "resolved": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#3653495c525e880f0430ec9cda7032c81fbd8306"
+      "resolved": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#30edac0c792d080e8a367dafb4909e3b57080d94"
     },
     "tmp": {
       "version": "0.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "2.3.0-dev",
+  "version": "2.5.0-dev",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
   "generator-core-version": "^3.4.0",


### PR DESCRIPTION
Improve speed of getting a pixmap, by reducing the cases in which we need to do _getSettingsWithExactBounds

Squashed commit of the following:
commit d3843d7780093abec893ed51a0f6fa3340b5944f
Merge: 0a40204 90a3584
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Wed Oct 21 15:28:23 2015 -0700

    Merge branch 'master' into vmitnick/layer-effect-optimiz

commit 0a402045a78feddaf70d428f9ede72be13290233
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Wed Oct 21 10:32:24 2015 -0700

    Fix a half-typo that was left over after merging with master.

commit 3578c4879e756b219f3ac66565b348b80271a3ea
Merge: a39e635 ced18ed
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Tue Oct 20 16:49:26 2015 -0700

    Merge branch 'master' into vmitnick/layer-effect-optimiz

commit a39e6357f88adbe433ae3b1a25a2ac931bb84431
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Tue Oct 20 15:36:58 2015 -0700

    Remove a couple debugging log statements.

commit 6e6818aea2ea518091c056f7528a1d0913d24193
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Tue Oct 20 12:58:42 2015 -0700

    In DocumentManager, add new function clearDeferred(), which can be used
    when the caller (e.g. devicePreview) needs to be sure that there are no
    lingering deferred promises for getDocument.
    In PixmapRenderer.prototype._getData(), clean up hasComplexTransform a bit, to include the check
    for existence of layer.

commit 80945a3296a59e41d5ea9193e6c78e61623d78cc
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Mon Oct 19 14:53:27 2015 -0700

    In _componentHasLayerEffects(), ignore layerEffects for layers that
    are directly or indirectly invisible, that can't make the layer bigger, or
    that don't cause the layer to cross the bounds of its container (document
    or artboard).
    In _getData(), only be concerned with hasComplexTransform for layers/layer groups,
    not for whole documents.

