### PR TITLE
Adding support of handling complex masks applied to Layer group.

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1150,7 +1150,7 @@
         var layerGroupHasComplexMasks = function (layer) {
             return layer.layers &&
                     ((layer.mask && layer.mask.enabled && layer.mask.extendWithWhite) ||
-                    ((layer.mask || layer.path) && !layer.getTotalMaskBounds()));
+                     ((layer.mask || layer.path) && !layer.getTotalMaskBounds()));
         };
         if (component.layer) {
             return component.layer.visit(layerGroupHasComplexMasks);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1101,6 +1101,7 @@
      * 
      * @private
      * @param {!Component} component 
+     * @return {boolean}
      */
     PixmapRenderer.prototype._componentHasLayerEffects = function (component) {
         var layerHasEffects = function (layer) {
@@ -1119,6 +1120,7 @@
      * 
      * @private
      * @param {!Component} component 
+     * @return {boolean}
      */
     PixmapRenderer.prototype._componentHasZeroBounds = function (component) {
         var hasZeroBounds = function (bounds) {
@@ -1142,12 +1144,13 @@
      * (2) Vector masks or Bitmap Mask with zero bounds.(Layer Mask>Hide All or Vector Mask>Hide All)
      * @private
      * @param {!Component} component 
+     * @return {boolean}
      */
     PixmapRenderer.prototype._componentHasComplexMasks = function (component) {
         var layerGroupHasComplexMasks = function (layer) {
             return layer.layers &&
-                    (layer.mask && layer.mask.enabled && layer.mask.extendWithWhite) ||
-                    ((layer.mask || layer.path) && !layer.getTotalMaskBounds());
+                    ((layer.mask && layer.mask.enabled && layer.mask.extendWithWhite) ||
+                    ((layer.mask || layer.path) && !layer.getTotalMaskBounds()));
         };
         if (component.layer) {
             return component.layer.visit(layerGroupHasComplexMasks);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1134,6 +1134,27 @@
         
         return hasZeroBounds(this._getContentBounds(component.document.layers));
     };
+
+    /**
+     * checks to see if there is any complex mask applied to any of the layerGroup. 
+     * Complex Mask is defined as : 
+     * (1) Bitmap masks with extendWithWhite Property (Photoshop>Layers>Layer Mask>Hide Selection)
+     * (2) Vector masks or Bitmap Mask with zero bounds.(Layer Mask>Hide All or Vector Mask>Hide All)
+     * @private
+     * @param {!Component} component 
+     */
+    PixmapRenderer.prototype._componentHasComplexMasks = function (component) {
+        var layerGroupHasComplexMasks = function (layer) {
+            return layer.layers &&
+                    (layer.mask && layer.mask.enabled && layer.mask.extendWithWhite) ||
+                    ((layer.mask || layer.path) && !layer.getTotalMaskBounds());
+        };
+        if (component.layer) {
+            return component.layer.visit(layerGroupHasComplexMasks);
+        }
+        
+        return component.document.layers.visit(layerGroupHasComplexMasks);
+    };
         
     /**
      * Get pixmap data for the given component.
@@ -1151,10 +1172,12 @@
         // 1. The component is either not scaled, or is only scaled by an integral
         //    factor (i.e, 100%, 200%, etc.)
         // 2. The layer does not have an enabled mask
-        // 3. The layer does not have any enabled layer effects
+        // 3. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
         // 4. The "include-ancestor-masks" config option is NOT set
-        // 5. None of the layers has zero bounds. Sometimes they aren't computed and set to all 0's
-        // 6. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
+        // 5. The layer does not have any enabled layer effects
+        // 6. Component is not resulting in zero bounds.
+        // 7. None of the layerGroup has any complexMask.(Ideally, we should try to handle 
+        //    complexMask calculations/corrections in getContentBounds.)
         var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
                 component.hasOwnProperty("width") || component.hasOwnProperty("height"),
             canvasDimensionsScale = 1,
@@ -1164,17 +1187,16 @@
             resultPromise,
             isClipped = layer && layer.clipped,
             hasMask = layer && layer.getTotalMaskBounds(),
-            includeAncestorMasks = layer && this._includeAncestorMasks,
-            hasEffects = this._componentHasLayerEffects(component),
-            hasZeroBounds = this._componentHasZeroBounds(component);
+            includeAncestorMasks = layer && this._includeAncestorMasks;
         
         //hasComplexTransform is the only part of this test that affects layerComp
         if (hasComplexTransform ||
             hasMask ||
-            hasEffects ||
-            hasZeroBounds ||
             isClipped ||
-            includeAncestorMasks) {
+            includeAncestorMasks ||
+            this._componentHasLayerEffects(component) ||
+            this._componentHasZeroBounds(component) ||
+            this._componentHasComplexMasks(component)) {
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {


### PR DESCRIPTION
If fixes the bug : Quick Export Not Respecting Document Boundaries (file with layer mask) - 4019840


