### PR TITLE
Squashed commit of the following:

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1097,20 +1097,48 @@
     };
     
     /**
-     * checks to see if there is any part of the component that might extend due to layer effects
+     * Checks to see if there is any part of the component that might extend due to layer effects.
+     * Limit to a) layer effects that can actually enlarge a layer, and b) layers which, including
+     * their effects, touch the edge of the relevant container (document or artboard).
+     * (Mostly, we care about layers crossing the edges of the container, but in the case of
+     * a layerGroup, its bounds already account for the child layers with effects.)
      * 
      * @private
      * @param {!Component} component 
      */
     PixmapRenderer.prototype._componentHasLayerEffects = function (component) {
+        var componentBounds;
+
         var layerHasEffects = function (layer) {
-            return layer && layer.layerEffects && layer.layerEffects.isEnabled();
+            if (!layer || layer.visible === false || layer.group && layer.group.visible === false) {
+                return false;
+            }
+            var hasEffect = layer.layerEffects && (
+                (layer.layerEffects.bevelEmboss && layer.layerEffects.bevelEmboss.enabled) ||
+                (layer.layerEffects.dropShadow && layer.layerEffects.dropShadow.enabled) ||
+                (layer.layerEffects.outerGlow && layer.layerEffects.outerGlow.enabled) ||
+                (layer.layerEffects.frameFX && layer.layerEffects.enabled));
+            
+            if (hasEffect) {
+                if ((layer.boundsWithFX.left <= componentBounds.left) ||
+                    (layer.boundsWithFX.right >= componentBounds.right) ||
+                    (layer.boundsWithFX.bottom >= componentBounds.bottom) ||
+                    (layer.boundsWithFX.top <= componentBounds.top)) {
+                    
+                    return true;
+                }
+
+            } else {
+                return false;
+            }
         };
         
         if (component.layer) {
+            componentBounds = component.layer.bounds;
             return component.layer.visit(layerHasEffects);
         }
         
+        componentBounds = component.document.bounds;
         return component.document.layers.visit(layerHasEffects);
     };
 
@@ -1155,10 +1183,12 @@
         // 4. The "include-ancestor-masks" config option is NOT set
         // 5. None of the layers has zero bounds. Sometimes they aren't computed and set to all 0's
         // 6. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
-        var hasComplexTransform = (component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
-                component.hasOwnProperty("width") || component.hasOwnProperty("height"),
+        var layer = component.layer,
+            hasComplexTransform = layer &&
+                ((component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
+                  component.hasOwnProperty("width") ||
+                  component.hasOwnProperty("height")),
             canvasDimensionsScale = 1,
-            layer = component.layer,
             layerComp = component.comp,
             settingsPromise,
             resultPromise,
@@ -1168,13 +1198,13 @@
             hasEffects = this._componentHasLayerEffects(component),
             hasZeroBounds = this._componentHasZeroBounds(component);
         
-        //hasComplexTransform is the only part of this test that affects layerComp
         if (hasComplexTransform ||
             hasMask ||
             hasEffects ||
             hasZeroBounds ||
             isClipped ||
             includeAncestorMasks) {
+
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);
         } else {


### PR DESCRIPTION
commit d3843d7780093abec893ed51a0f6fa3340b5944f
Merge: 0a40204 90a3584
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Wed Oct 21 15:28:23 2015 -0700

    Merge branch 'master' into vmitnick/layer-effect-optimiz

commit 0a402045a78feddaf70d428f9ede72be13290233
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Wed Oct 21 10:32:24 2015 -0700

    Fix a half-typo that was left over after merging with master.

commit 3578c4879e756b219f3ac66565b348b80271a3ea
Merge: a39e635 ced18ed
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Tue Oct 20 16:49:26 2015 -0700

    Merge branch 'master' into vmitnick/layer-effect-optimiz

commit a39e6357f88adbe433ae3b1a25a2ac931bb84431
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Tue Oct 20 15:36:58 2015 -0700

    Remove a couple debugging log statements.

commit 6e6818aea2ea518091c056f7528a1d0913d24193
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Tue Oct 20 12:58:42 2015 -0700

    In DocumentManager, add new function clearDeferred(), which can be used
    when the caller (e.g. devicePreview) needs to be sure that there are no
    lingering deferred promises for getDocument.
    In PixmapRenderer.prototype._getData(), clean up hasComplexTransform a bit, to include the check
    for existence of layer.

commit 80945a3296a59e41d5ea9193e6c78e61623d78cc
Author: Vic Mitnick <vmitnick@adobe.com>
Date:   Mon Oct 19 14:53:27 2015 -0700

    In _componentHasLayerEffects(), ignore layerEffects for layers that
    are directly or indirectly invisible, that can't make the layer bigger, or
    that don't cause the layer to cross the bounds of its container (document
    or artboard).
    In _getData(), only be concerned with hasComplexTransform for layers/layer groups,
    not for whole documents.

    Note; There are a couple logging statements present here that will be removed before this is merged.

Remove trailing whitespace

In _componentHasLayerEffects, when we consider whether a layer that has been enlarged due to a layer effect
also changes the size of its container, now at bounds being "beyond or equal" to the bounds of the container,
instead of just "beyond". This is because for a layerGroup that contains a layer with a (growing) effect,
the layerGroup's bounds already take the efect into account, so it was looking like the effect didn't make
the layer go outside the layerGroup.