### PR TITLE
Adding check for complex Masks on Layer group

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1105,6 +1105,7 @@
      * 
      * @private
      * @param {!Component} component 
+     * @return {boolean}
      */
     PixmapRenderer.prototype._componentHasLayerEffects = function (component) {
         var componentBounds;
@@ -1147,6 +1148,7 @@
      * 
      * @private
      * @param {!Component} component 
+     * @return {boolean}
      */
     PixmapRenderer.prototype._componentHasZeroBounds = function (component) {
         var hasZeroBounds = function (bounds) {
@@ -1161,6 +1163,28 @@
         }
         
         return hasZeroBounds(this._getContentBounds(component.document.layers));
+    };
+
+    /**
+     * checks to see if there is any complex mask applied to any of the layerGroup. 
+     * Complex Mask is defined as : 
+     * (1) Bitmap masks with extendWithWhite Property (Photoshop>Layers>Layer Mask>Hide Selection)
+     * (2) Vector masks or Bitmap Mask with zero bounds.(Layer Mask>Hide All or Vector Mask>Hide All)
+     * @private
+     * @param {!Component} component 
+     * @return {boolean}
+     */
+    PixmapRenderer.prototype._componentHasComplexMasks = function (component) {
+        var layerGroupHasComplexMasks = function (layer) {
+            return layer.layers &&
+                    ((layer.mask && layer.mask.enabled && layer.mask.extendWithWhite) ||
+                     ((layer.mask || layer.path) && !layer.getTotalMaskBounds()));
+        };
+        if (component.layer) {
+            return component.layer.visit(layerGroupHasComplexMasks);
+        }
+        
+        return component.document.layers.visit(layerGroupHasComplexMasks);
     };
         
     /**
@@ -1179,10 +1203,12 @@
         // 1. The component is either not scaled, or is only scaled by an integral
         //    factor (i.e, 100%, 200%, etc.)
         // 2. The layer does not have an enabled mask
-        // 3. The layer does not have any enabled layer effects
+        // 3. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
         // 4. The "include-ancestor-masks" config option is NOT set
-        // 5. None of the layers has zero bounds. Sometimes they aren't computed and set to all 0's
-        // 6. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
+        // 5. The layer does not have any enabled layer effects
+        // 6. Component is not resulting in zero bounds.
+        // 7. None of the layerGroup has any complexMask.(Ideally, we should try to handle 
+        //    complexMask calculations/corrections in getContentBounds.)
         var layer = component.layer,
             hasComplexTransform = layer &&
                 ((component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
@@ -1194,16 +1220,15 @@
             resultPromise,
             isClipped = layer && layer.clipped,
             hasMask = layer && layer.getTotalMaskBounds(),
-            includeAncestorMasks = layer && this._includeAncestorMasks,
-            hasEffects = this._componentHasLayerEffects(component),
-            hasZeroBounds = this._componentHasZeroBounds(component);
+            includeAncestorMasks = layer && this._includeAncestorMasks;
         
         if (hasComplexTransform ||
             hasMask ||
-            hasEffects ||
-            hasZeroBounds ||
             isClipped ||
-            includeAncestorMasks) {
+            includeAncestorMasks ||
+            this._componentHasLayerEffects(component) ||
+            this._componentHasZeroBounds(component) ||
+            this._componentHasComplexMasks(component)) {
 
             //do the more expensive check
             settingsPromise = this._getSettingsWithExactBounds(component);


### PR DESCRIPTION
Adding check for complex Masks on Layer group. In such presence we should resort to `_getSettingsWithExactBounds()`.

It fixes the bug : Quick Export Not Respecting Document Boundaries (file with layer mask) - 4019840

Creating new for https://github.com/adobe-photoshop/generator-assets/pull/376 since the merge was complex and there was risk of loosing some changes.