### PR TITLE
In fnHandlePixmap, check again to make sure the pixmap isn't empty, …

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1304,6 +1304,14 @@
             }
             
             var fnHandlePixmap = function (pixmap) {
+                // We look for empty pixmap in _getSettingsWithExactBounds and _getSettingsWithApproximateBounds,
+                // but check again here, in case the doc has changed in that small time interval.
+                if (pixmap.width === 0 || pixmap.height === 0) {
+                    var error = new Error("Got a pixmap with zero bounds.");
+                    error.zeroBoundsError = true;
+                    throw error;
+                }
+                
                 var padding = pixmapSettings.hasOwnProperty("getPadding") ?
                         pixmapSettings.getPadding(pixmap.width, pixmap.height) : undefined,
                     extract =  pixmapSettings.hasOwnProperty("getExtractParamsForDocBounds") ?


### PR DESCRIPTION
…in case the user changed it

since we last checked when calculating the bounds. Without this check, if the user quickly makes
layers in an artboard invisible & vislble, we can get caught in a race and crash generator.