### PR TITLE
use new api to embed icc color profile in images

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -74,6 +74,10 @@
         if (config.hasOwnProperty("icc-profile")) {
             this._useICCProfile = config["icc-profile"];
         }
+        
+        if (config.hasOwnProperty("embed-icc-profile")) {
+            this._embedICCProfile = config["embed-icc-profile"];
+        }
 
         if (config.hasOwnProperty("allow-dither")) {
             this._allowDither = !!config["allow-dither"];
@@ -136,6 +140,12 @@
      * the _convertColorSpace flag. A common value is "sRGB IEC61966-2.1"
      */
     BaseRenderer.prototype._useICCProfile = undefined;
+    
+    /**
+     * @type {boolean=}
+     * Whether to embed the ICC profile into the file image or not
+     */
+    BaseRenderer.prototype._embedICCProfile = undefined;
 
     /**
      * @type {boolean=}
@@ -1296,6 +1306,12 @@
                 pixmapSettings.useICCProfile = component.useICCProfile;
             } else if (this._useICCProfile !== undefined) {
                 pixmapSettings.useICCProfile = this._useICCProfile;
+            }
+            
+            if (component.hasOwnProperty("embedICCProfile")) {
+                pixmapSettings.getICCProfileData = component.embedICCProfile;
+            } else if (this._embedICCProfile !== undefined) {
+                pixmapSettings.getICCProfileData = this._embedICCProfile;
             }
 
             if (this._allowDither !== undefined) {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "generator-assets",
-  "version": "2.5.0-dev",
+  "version": "2.6.0",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
-  "generator-core-version": "^3.4.0",
+  "generator-core-version": "^3.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe-photoshop/generator-assets"


### PR DESCRIPTION
use new api to embed icc color profile in images generated by flitetranscoder

This is the companion pull to https://github.com/adobe-photoshop/generator-core/pull/326