### PR TITLE
add leading delimiters to the parser's valid expressions

### DIFF
--- a/etc/layernames.pegjs
+++ b/etc/layernames.pegjs
@@ -95,8 +95,10 @@ defaultspec "A single default specification component"
     }
 
 speclist "List of layer specifications"
-    = first:spec [+,] rest:speclist {
-        rest.unshift(first); 
+    = first:spec? [+,] rest:speclist {
+        if (first) {
+            rest.unshift(first);
+        }
         return rest; 
     }
     / only:spec {
@@ -109,6 +111,9 @@ spec "Layer specification"
         return {
             name: layername.trim()
         };
+    }
+    / _ {
+        return;
     }
 
 folder "A single folder name that ends with a slash and does not begin with a dot"
@@ -287,7 +292,7 @@ goodchars "A sequence of characters, excluding dots"
         return chars.join("");
     }
 
-char "A character, including dots"
+char "A character, including dots, excluding delimiters [+,]"
     = [^,+]
 
 goodchar "A character, excluding dots and other weird things"

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -79,7 +79,9 @@ module.exports = (function() {
             },
         peg$c17 = { type: "other", description: "List of layer specifications" },
         peg$c18 = function(first, rest) {
-                rest.unshift(first); 
+                if (first) {
+                    rest.unshift(first);
+                }
                 return rest; 
             },
         peg$c19 = { type: "other", description: "Layer specification" },
@@ -88,15 +90,18 @@ module.exports = (function() {
                     name: layername.trim()
                 };
             },
-        peg$c21 = { type: "other", description: "A single folder name that ends with a slash and does not begin with a dot" },
-        peg$c22 = "/",
-        peg$c23 = { type: "literal", value: "/", description: "\"/\"" },
-        peg$c24 = function(chars) { return chars[0] == "."; },
-        peg$c25 = function(chars) {
+        peg$c21 = function() {
+                return;
+            },
+        peg$c22 = { type: "other", description: "A single folder name that ends with a slash and does not begin with a dot" },
+        peg$c23 = "/",
+        peg$c24 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c25 = function(chars) { return chars[0] == "."; },
+        peg$c26 = function(chars) {
                 return chars;
             },
-        peg$c26 = { type: "other", description: "A size-and-file specification" },
-        peg$c27 = function(size, canvasrect, folders, filepart) { // Parsed layer name part
+        peg$c27 = { type: "other", description: "A size-and-file specification" },
+        peg$c28 = function(size, canvasrect, folders, filepart) { // Parsed layer name part
                 var result = {
                     name: text().trim(),
                     file: filepart.filename.replace(/[\\":*?<>!|]/g,'_'),
@@ -116,8 +121,8 @@ module.exports = (function() {
                 
                 return result;
             },
-        peg$c28 = { type: "other", description: "Filename and quality suffix" },
-        peg$c29 = function(nameparts, suffix) {
+        peg$c29 = { type: "other", description: "Filename and quality suffix" },
+        peg$c30 = function(nameparts, suffix) {
                 var filename = String.prototype.concat.apply("", nameparts) + suffix.extension;
                 if (filename.match(/^\s/)) {
                     error("Filename begins with whitespace");
@@ -134,10 +139,10 @@ module.exports = (function() {
 
                 return result;
             },
-        peg$c30 = { type: "other", description: "File extension and quality suffix" },
-        peg$c31 = /^[a-zA-Z]/,
-        peg$c32 = { type: "class", value: "[a-zA-Z]", description: "[a-zA-Z]" },
-        peg$c33 = function(extension, quality) {
+        peg$c31 = { type: "other", description: "File extension and quality suffix" },
+        peg$c32 = /^[a-zA-Z]/,
+        peg$c33 = { type: "class", value: "[a-zA-Z]", description: "[a-zA-Z]" },
+        peg$c34 = function(extension, quality) {
                 var result = {
                     extension: extension.join(""),
                 };
@@ -148,32 +153,32 @@ module.exports = (function() {
 
                 return result;
             },
-        peg$c34 = { type: "other", description: "Quality parameter that follows a file extension" },
-        peg$c35 = "-",
-        peg$c36 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c37 = /^[a-z]/,
-        peg$c38 = { type: "class", value: "[a-z]", description: "[a-z]" },
-        peg$c39 = "%",
-        peg$c40 = { type: "literal", value: "%", description: "\"%\"" },
-        peg$c41 = function(param, ext) {
+        peg$c35 = { type: "other", description: "Quality parameter that follows a file extension" },
+        peg$c36 = "-",
+        peg$c37 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c38 = /^[a-z]/,
+        peg$c39 = { type: "class", value: "[a-z]", description: "[a-z]" },
+        peg$c40 = "%",
+        peg$c41 = { type: "literal", value: "%", description: "\"%\"" },
+        peg$c42 = function(param, ext) {
                 return param.join("") + (ext || "");
             },
-        peg$c42 = { type: "other", description: "Relative or absolute scale" },
-        peg$c43 = " ",
-        peg$c44 = { type: "literal", value: " ", description: "\" \"" },
-        peg$c45 = function(abs) {
+        peg$c43 = { type: "other", description: "Relative or absolute scale" },
+        peg$c44 = " ",
+        peg$c45 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c46 = function(abs) {
                 return abs;
             },
-        peg$c46 = { type: "other", description: "Relative scale, like 0.3" },
-        peg$c47 = function(scale) {
+        peg$c47 = { type: "other", description: "Relative scale, like 0.3" },
+        peg$c48 = function(scale) {
                 return {
                     scale: scale
                 };
             },
-        peg$c48 = { type: "other", description: "Absolute scale, like 50x100cm" },
-        peg$c49 = "x",
-        peg$c50 = { type: "literal", value: "x", description: "\"x\"" },
-        peg$c51 = function(width, height) {
+        peg$c49 = { type: "other", description: "Absolute scale, like 50x100cm" },
+        peg$c50 = "x",
+        peg$c51 = { type: "literal", value: "x", description: "\"x\"" },
+        peg$c52 = function(width, height) {
                 var result = {};
 
                 if (width.hasOwnProperty("value")) {
@@ -194,8 +199,8 @@ module.exports = (function() {
 
                 return result;
             },
-        peg$c52 = { type: "other", description: "Absolute scale component, like 100cm" },
-        peg$c53 = function(value, unit) {
+        peg$c53 = { type: "other", description: "Absolute scale component, like 100cm" },
+        peg$c54 = function(value, unit) {
                 var result = {
                     value: value,
                 };
@@ -206,73 +211,73 @@ module.exports = (function() {
 
                 return result;
             },
-        peg$c54 = "?",
-        peg$c55 = { type: "literal", value: "?", description: "\"?\"" },
-        peg$c56 = function() { // wildcard component
+        peg$c55 = "?",
+        peg$c56 = { type: "literal", value: "?", description: "\"?\"" },
+        peg$c57 = function() { // wildcard component
                 return {
                     // no unit
                 };
             },
-        peg$c57 = { type: "other", description: "Component canvas rect, either long or short form without offsets, or long form with offsets" },
-        peg$c58 = { type: "other", description: "Long form component canvas size, like [32x64], offset support to get added later" },
-        peg$c59 = "[",
-        peg$c60 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c61 = "]",
-        peg$c62 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c63 = function(csize, w, h) {
+        peg$c58 = { type: "other", description: "Component canvas rect, either long or short form without offsets, or long form with offsets" },
+        peg$c59 = { type: "other", description: "Long form component canvas size, like [32x64], offset support to get added later" },
+        peg$c60 = "[",
+        peg$c61 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c62 = "]",
+        peg$c63 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c64 = function(csize, w, h) {
                 return {width: w, height: h};
             },
-        peg$c64 = { type: "other", description: "Long form component canvas size, like [32x64+11-23], with offsets" },
-        peg$c65 = /^[+\-]/,
-        peg$c66 = { type: "class", value: "[+\\-]", description: "[+\\-]" },
-        peg$c67 = function(csize, w, h, xsign, x, ysign, y) {
+        peg$c65 = { type: "other", description: "Long form component canvas size, like [32x64+11-23], with offsets" },
+        peg$c66 = /^[+\-]/,
+        peg$c67 = { type: "class", value: "[+\\-]", description: "[+\\-]" },
+        peg$c68 = function(csize, w, h, xsign, x, ysign, y) {
                 return {width: w, height: h,
                     x: xsign === "+" ? x : -1 * x,
                     y: ysign === "+" ? y : -1 * y };
             },
-        peg$c68 = { type: "other", description: "short form component canvas rect to just set a common width/height, like [32]" },
-        peg$c69 = function(csize, val) {
+        peg$c69 = { type: "other", description: "short form component canvas rect to just set a common width/height, like [32]" },
+        peg$c70 = function(csize, val) {
                 return {width: val, height: val};
             },
-        peg$c70 = { type: "other", description: "Unit abbreviation" },
-        peg$c71 = /^[a-z]/i,
-        peg$c72 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
-        peg$c73 = function(first, second) {
+        peg$c71 = { type: "other", description: "Unit abbreviation" },
+        peg$c72 = /^[a-z]/i,
+        peg$c73 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
+        peg$c74 = function(first, second) {
                 return first + second;
             },
-        peg$c74 = { type: "other", description: "A percentage, like 30%" },
-        peg$c75 = function(num) {
+        peg$c75 = { type: "other", description: "A percentage, like 30%" },
+        peg$c76 = function(num) {
                 return num / 100;
             },
-        peg$c76 = function(chars) {
+        peg$c77 = function(chars) {
                 return chars.join("")
             },
-        peg$c77 = { type: "other", description: "A good character or a dot" },
-        peg$c78 = ".",
-        peg$c79 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c80 = { type: "other", description: "A sequence of characters that ends with a dot" },
-        peg$c81 = function(chars) {
+        peg$c78 = { type: "other", description: "A good character or a dot" },
+        peg$c79 = ".",
+        peg$c80 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c81 = { type: "other", description: "A sequence of characters that ends with a dot" },
+        peg$c82 = function(chars) {
                 return chars.concat(".");
             },
-        peg$c82 = { type: "other", description: "A sequence of characters, including dots" },
-        peg$c83 = function(chars) {
+        peg$c83 = { type: "other", description: "A sequence of characters, including dots" },
+        peg$c84 = function(chars) {
                 return chars.join("");
             },
-        peg$c84 = { type: "other", description: "A sequence of characters, excluding dots" },
-        peg$c85 = { type: "other", description: "A character, including dots" },
-        peg$c86 = /^[^,+]/,
-        peg$c87 = { type: "class", value: "[^,+]", description: "[^,+]" },
-        peg$c88 = { type: "other", description: "A character, excluding dots and other weird things" },
-        peg$c89 = /^[^+,.\/\0-\x1F]/,
-        peg$c90 = { type: "class", value: "[^+,.\\/\\0-\\x1F]", description: "[^+,.\\/\\0-\\x1F]" },
-        peg$c91 = { type: "other", description: "A nonnegative number, which may or may not have leading zeros" },
-        peg$c92 = function(parts) { return parseFloat(parts); },
-        peg$c93 = function(parts) { return parseFloat("0" + parts); },
-        peg$c94 = /^[0-9]/,
-        peg$c95 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c96 = { type: "other", description: "whitespace" },
-        peg$c97 = /^[ \t\n\r]/,
-        peg$c98 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c85 = { type: "other", description: "A sequence of characters, excluding dots" },
+        peg$c86 = { type: "other", description: "A character, including dots, excluding delimiters [+,]" },
+        peg$c87 = /^[^,+]/,
+        peg$c88 = { type: "class", value: "[^,+]", description: "[^,+]" },
+        peg$c89 = { type: "other", description: "A character, excluding dots and other weird things" },
+        peg$c90 = /^[^+,.\/\0-\x1F]/,
+        peg$c91 = { type: "class", value: "[^+,.\\/\\0-\\x1F]", description: "[^+,.\\/\\0-\\x1F]" },
+        peg$c92 = { type: "other", description: "A nonnegative number, which may or may not have leading zeros" },
+        peg$c93 = function(parts) { return parseFloat(parts); },
+        peg$c94 = function(parts) { return parseFloat("0" + parts); },
+        peg$c95 = /^[0-9]/,
+        peg$c96 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c97 = { type: "other", description: "whitespace" },
+        peg$c98 = /^[ \t\n\r]/,
+        peg$c99 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -697,6 +702,9 @@ module.exports = (function() {
       peg$silentFails++;
       s0 = peg$currPos;
       s1 = peg$parsespec();
+      if (s1 === peg$FAILED) {
+        s1 = peg$c13;
+      }
       if (s1 !== peg$FAILED) {
         if (peg$c7.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
@@ -779,6 +787,15 @@ module.exports = (function() {
           peg$currPos = s0;
           s0 = peg$c2;
         }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parse_();
+          if (s1 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c21();
+          }
+          s0 = s1;
+        }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
@@ -807,15 +824,15 @@ module.exports = (function() {
       s1 = peg$parsegoodcharsanddots();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s2 = peg$c22;
+          s2 = peg$c23;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c23); }
+          if (peg$silentFails === 0) { peg$fail(peg$c24); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = peg$currPos;
-          s3 = peg$c24(s1);
+          s3 = peg$c25(s1);
           if (s3) {
             s3 = peg$c2;
           } else {
@@ -823,7 +840,7 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c25(s1);
+            s1 = peg$c26(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -840,7 +857,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -889,7 +906,7 @@ module.exports = (function() {
                     s8 = peg$parse_();
                     if (s8 !== peg$FAILED) {
                       peg$reportedPos = s0;
-                      s1 = peg$c27(s2, s4, s6, s7);
+                      s1 = peg$c28(s2, s4, s6, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -926,7 +943,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c26); }
+        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -961,7 +978,7 @@ module.exports = (function() {
         s2 = peg$parsefileext();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c29(s1, s2);
+          s1 = peg$c30(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -974,7 +991,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c28); }
+        if (peg$silentFails === 0) { peg$fail(peg$c29); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -996,22 +1013,22 @@ module.exports = (function() {
       peg$silentFails++;
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c31.test(input.charAt(peg$currPos))) {
+      if (peg$c32.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c32); }
+        if (peg$silentFails === 0) { peg$fail(peg$c33); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c31.test(input.charAt(peg$currPos))) {
+          if (peg$c32.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c33); }
           }
         }
       } else {
@@ -1024,7 +1041,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c33(s1, s2);
+          s1 = peg$c34(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1037,7 +1054,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c30); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1059,11 +1076,11 @@ module.exports = (function() {
       peg$silentFails++;
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c35;
+        s1 = peg$c36;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
       }
       if (s1 === peg$FAILED) {
         s1 = peg$c13;
@@ -1071,20 +1088,20 @@ module.exports = (function() {
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedigits();
         if (s2 !== peg$FAILED) {
-          if (peg$c37.test(input.charAt(peg$currPos))) {
+          if (peg$c38.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c38); }
+            if (peg$silentFails === 0) { peg$fail(peg$c39); }
           }
           if (s3 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 37) {
-              s3 = peg$c39;
+              s3 = peg$c40;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c40); }
+              if (peg$silentFails === 0) { peg$fail(peg$c41); }
             }
           }
           if (s3 === peg$FAILED) {
@@ -1092,7 +1109,7 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c41(s2, s3);
+            s1 = peg$c42(s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1109,7 +1126,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1135,15 +1152,15 @@ module.exports = (function() {
         s1 = peg$parseabsscale();
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s2 = peg$c43;
+            s2 = peg$c44;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c45); }
           }
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c45(s1);
+            s1 = peg$c46(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1157,7 +1174,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c42); }
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1181,13 +1198,13 @@ module.exports = (function() {
       s1 = peg$parsepercent();
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c47(s1);
+        s1 = peg$c48(s1);
       }
       s0 = s1;
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1212,12 +1229,12 @@ module.exports = (function() {
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c49) {
+          if (input.substr(peg$currPos, 1).toLowerCase() === peg$c50) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c51); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
@@ -1225,7 +1242,7 @@ module.exports = (function() {
               s5 = peg$parseabscomp();
               if (s5 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c51(s1, s5);
+                s1 = peg$c52(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1250,7 +1267,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1279,7 +1296,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c53(s1, s2);
+          s1 = peg$c54(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1292,22 +1309,22 @@ module.exports = (function() {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 63) {
-          s1 = peg$c54;
+          s1 = peg$c55;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c56); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c56();
+          s1 = peg$c57();
         }
         s0 = s1;
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c52); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1337,7 +1354,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1359,35 +1376,35 @@ module.exports = (function() {
       peg$silentFails++;
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c59;
+        s1 = peg$c60;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsenumber();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 120) {
-            s3 = peg$c49;
+            s3 = peg$c50;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c51); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsenumber();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c61;
+                s5 = peg$c62;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                if (peg$silentFails === 0) { peg$fail(peg$c63); }
               }
               if (s5 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c63(s1, s2, s4);
+                s1 = peg$c64(s1, s2, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1412,7 +1429,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c58); }
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1434,55 +1451,55 @@ module.exports = (function() {
       peg$silentFails++;
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c59;
+        s1 = peg$c60;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsenumber();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 120) {
-            s3 = peg$c49;
+            s3 = peg$c50;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c51); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsenumber();
             if (s4 !== peg$FAILED) {
-              if (peg$c65.test(input.charAt(peg$currPos))) {
+              if (peg$c66.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c66); }
+                if (peg$silentFails === 0) { peg$fail(peg$c67); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parsenumber();
                 if (s6 !== peg$FAILED) {
-                  if (peg$c65.test(input.charAt(peg$currPos))) {
+                  if (peg$c66.test(input.charAt(peg$currPos))) {
                     s7 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c66); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c67); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parsenumber();
                     if (s8 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 93) {
-                        s9 = peg$c61;
+                        s9 = peg$c62;
                         peg$currPos++;
                       } else {
                         s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c63); }
                       }
                       if (s9 !== peg$FAILED) {
                         peg$reportedPos = s0;
-                        s1 = peg$c67(s1, s2, s4, s5, s6, s7, s8);
+                        s1 = peg$c68(s1, s2, s4, s5, s6, s7, s8);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1523,7 +1540,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1545,25 +1562,25 @@ module.exports = (function() {
       peg$silentFails++;
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c59;
+        s1 = peg$c60;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsenumber();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 93) {
-            s3 = peg$c61;
+            s3 = peg$c62;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c62); }
+            if (peg$silentFails === 0) { peg$fail(peg$c63); }
           }
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c69(s1, s2);
+            s1 = peg$c70(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1580,7 +1597,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c69); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1601,24 +1618,24 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = peg$currPos;
-      if (peg$c71.test(input.charAt(peg$currPos))) {
+      if (peg$c72.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c71.test(input.charAt(peg$currPos))) {
+        if (peg$c72.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c73(s1, s2);
+          s1 = peg$c74(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1631,7 +1648,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1655,15 +1672,15 @@ module.exports = (function() {
       s1 = peg$parsenumber();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s2 = peg$c39;
+          s2 = peg$c40;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c41); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c75(s1);
+          s1 = peg$c76(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1676,7 +1693,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c75); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1708,7 +1725,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c76(s1);
+        s1 = peg$c77(s1);
       }
       s0 = s1;
 
@@ -1732,17 +1749,17 @@ module.exports = (function() {
       s0 = peg$parsegoodchar();
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s0 = peg$c78;
+          s0 = peg$c79;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c78); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1766,15 +1783,15 @@ module.exports = (function() {
       s1 = peg$parsegoodchars();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c78;
+          s2 = peg$c79;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c81(s1);
+          s1 = peg$c82(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1787,7 +1804,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1820,13 +1837,13 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c83(s1);
+        s1 = peg$c84(s1);
       }
       s0 = s1;
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1859,13 +1876,13 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c83(s1);
+        s1 = peg$c84(s1);
       }
       s0 = s1;
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1885,17 +1902,17 @@ module.exports = (function() {
       }
 
       peg$silentFails++;
-      if (peg$c86.test(input.charAt(peg$currPos))) {
+      if (peg$c87.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+        if (peg$silentFails === 0) { peg$fail(peg$c88); }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c86); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1915,17 +1932,17 @@ module.exports = (function() {
       }
 
       peg$silentFails++;
-      if (peg$c89.test(input.charAt(peg$currPos))) {
+      if (peg$c90.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c90); }
+        if (peg$silentFails === 0) { peg$fail(peg$c91); }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c88); }
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1952,11 +1969,11 @@ module.exports = (function() {
       if (s3 !== peg$FAILED) {
         s4 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s5 = peg$c78;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parsedigits();
@@ -1991,7 +2008,7 @@ module.exports = (function() {
       s1 = s2;
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c92(s1);
+        s1 = peg$c93(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1999,11 +2016,11 @@ module.exports = (function() {
         s1 = peg$currPos;
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c78;
+          s3 = peg$c79;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parsedigits();
@@ -2024,14 +2041,14 @@ module.exports = (function() {
         s1 = s2;
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c93(s1);
+          s1 = peg$c94(s1);
         }
         s0 = s1;
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+        if (peg$silentFails === 0) { peg$fail(peg$c92); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2077,12 +2094,12 @@ module.exports = (function() {
         return cached.result;
       }
 
-      if (peg$c94.test(input.charAt(peg$currPos))) {
+      if (peg$c95.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c95); }
+        if (peg$silentFails === 0) { peg$fail(peg$c96); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2111,7 +2128,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c96); }
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2130,12 +2147,12 @@ module.exports = (function() {
         return cached.result;
       }
 
-      if (peg$c97.test(input.charAt(peg$currPos))) {
+      if (peg$c98.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c98); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
 
       peg$cache[key] = { nextPos: peg$currPos, result: s0 };

--- a/test/test-parse-layer-name.js
+++ b/test/test-parse-layer-name.js
@@ -436,6 +436,12 @@
             // space before filename when folders are specificed is not allowed
             "folder/ test.jpg": [
                 { error: "Filename begins with whitespace" }
+            ],
+            "+foo": [
+                { name: "foo" }
+            ],
+            " +foo": [
+                { name: "foo" }
             ]
         };
         


### PR DESCRIPTION
fix for issue #388 

I changed the parser so that it can tolerate leading delimiters. I modified our main speclist rule to not require an initial valid character string which lets us filter out leading delimiters and spaces

changing this rule made  the string "+3.5" a legal string to begin a layer name with (which outputs the unused dictionary { name: "3.5"} )
while the layer name +3.5.jpg would create a asset with the name "3.5.jpg"

Also added a unit test for leading delimiter layer names ("+foo" and " +foo")