### PR TITLE
Delete a document's renderers when stopping or initializing an AssetManager

### DIFF
--- a/lib/rendermanager.js
+++ b/lib/rendermanager.js
@@ -326,7 +326,7 @@
     };
 
     /**
-     * Cancel all of a given document's render jobs.
+     * Cancel all of a given document's render jobs and purge its renderers
      * 
      * @see RenderManager.prototype.render
      */
@@ -335,6 +335,13 @@
             Object.keys(this._componentsByDocument[documentId]).forEach(function (componentId) {
                 this.cancel(componentId);
             }, this);
+        }
+
+        if (this._pixmapRenderers.hasOwnProperty(documentId)) {
+            delete this._pixmapRenderers[documentId];
+        }
+        if (this._svgRenderers.hasOwnProperty(documentId)) {
+            delete this._svgRenderers[documentId];
         }
     };
 


### PR DESCRIPTION
This addresses #389.

When handling an `imageChanged` event from photoshop, if a `bounds` property exists on the event then it is assumed that we'll need to re-fetch the entire document; see [here](https://github.com/adobe-photoshop/generator-assets/blob/6894b41c914ce2b196d36ef8f6c793525e9a755d/lib/dom/document.js#L772-L777).

The problem was that the `Document` to which the `renderer` had a reference was never updated.  The reset-document process nukes that document from the DocumentManager and re-fetches it.  But at render-time, the old stale renderer was retrieved from renderManager; [see here](https://github.com/adobe-photoshop/generator-assets/blob/6894b41c914ce2b196d36ef8f6c793525e9a755d/lib/rendermanager.js#L131) 

Separately, the "end" handler in `main.js`, which stops/re-starts the assets generation, causes the AssetManager to be completely re-initialized.  In spirit, it seems like that should also cause renderers to be destroyed.  So, I elaborated the existing `RenderManager.prototype.cancelAll()` to also destroy the document's renderers.

There are two separate processes involved: 1) the "end" event emitted by the document._applyChange method, when it sees `event.bounds`, which reboots asset generation, and 2) The ` DocumentManager.resetDocument()` which is called later as a result of document._applyChange failure.  It *seems* that the rendering (and thus the creation of the renderer with the freshest document) is correctly synchronized by the deferredDocuments process.

Almost forgot to tag some people: @pineapplespatula and @iwehrman - we discussed this issue last week.