### PR TITLE
Allow layer comps to be handled with complex transform

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1243,12 +1243,12 @@
         // 7. None of the layerGroup has any complexMask.(Ideally, we should try to handle 
         //    complexMask calculations/corrections in getContentBounds.)
         var layer = component.layer,
-            hasComplexTransform = layer &&
+            layerComp = component.comp,
+            hasComplexTransform = (layer || layerComp) &&
                 ((component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
                   component.hasOwnProperty("width") ||
                   component.hasOwnProperty("height")),
             canvasDimensionsScale = 1,
-            layerComp = component.comp,
             settingsPromise,
             resultPromise,
             isClipped = layer && layer.clipped,


### PR DESCRIPTION
This addresses #387 and, more importantly, a general regression that prevented layer comps from being scaled by providing height/width values.  I believe this was introduced by PR #374 which limited the `hasComplexTransform` calculation to components with layers.  This current PR relaxes that slightly to allow the calculation for layers *or* layer comps.  This ultimately allows `_getSettingsWithExactBounds` to be used, which handles the explicit width/height-based scaling.