### PR TITLE
 add support for jpeg optimal huffman encoding

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -59,6 +59,10 @@
         this._document = document;
         this._logger = logger;
 
+        if (config.hasOwnProperty("use-jpg-encoding")) {
+            this._useJPGEncoding = config["use-jpg-encoding"];
+        }
+
         if (config.hasOwnProperty("use-smart-scaling")) {
             this._useSmartScaling = !!config["use-smart-scaling"];
         }
@@ -115,6 +119,12 @@
             this._expandMaxDimensions = !!config["expand-max-dimensions"];
         }
     }
+
+    /**
+     * @type {String=}
+     * String witht he jpeg encoding string to use 
+     */
+    BaseRenderer.prototype._useJPGEncoding = undefined;
 
     /**
      * @type {boolean=}
@@ -1288,8 +1298,7 @@
             if (hasUniformTranform) {
                 this._ensureUniformTransform(pixmapSettings);
             }
-            
-            
+
             if (this._useSmartScaling !== undefined) {
                 pixmapSettings.useSmartScaling = this._useSmartScaling;
             }
@@ -1370,6 +1379,10 @@
                     settings.useFlite = component.useFlite;
                 } else if (this._useFlite !== undefined) {
                     settings.useFlite = this._useFlite;
+                }
+
+                if (this._useJPGEncoding !== undefined) {
+                    settings.useJPGEncoding = this._useJPGEncoding;
                 }
 
                 if (this._webpLossless !== undefined) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.6.0",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
-  "generator-core-version": "^3.6.0",
+  "generator-core-version": "^3.7.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe-photoshop/generator-assets"


### PR DESCRIPTION
Turns flite and jpeg optimal encoding on by default as well 
requires https://github.com/adobe-photoshop/generator-core/pull/334