### PR TITLE
dont assume inputRect and OutputRect always exist

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -745,8 +745,8 @@
      *
      * @private
      * @param {Component} component
-     * @return {Promise.<{inputRect: Bounds, outputRect: Bounds, expectedWidth: number,
-     *      expectedHeight: number, getPadding: function (number, number): number }>}
+     * @return {Promise.<{inputRect: Bounds=, outputRect: Bounds=, 
+     *                    getPadding: function (number, number): number }>}
      */
     PixmapRenderer.prototype._getSettingsWithExactBounds = function (component) {
         var ppi = this._document.resolution,
@@ -866,8 +866,8 @@
      *
      * @private
      * @param {Component} component
-     * @return {{inputRect: Bounds, outputRect: Bounds, expectedWidth: number,
-     *      expectedHeight: number, getPadding: function (number, number): number }}
+     * @return {{inputRect: Bounds, outputRect: Bounds, 
+     *     getPadding: function (number, number): number }}
      */
     PixmapRenderer.prototype._getSettingsWithApproximateBounds = function (component) {
         var scalar = component.scale || 1;
@@ -1084,6 +1084,10 @@
      * @param {{inputRect: object}, outputRect: object}} pixmapSettings
      */
     PixmapRenderer.prototype._ensureUniformTransform = function (pixmapSettings) {
+        if (!pixmapSettings.inputRect || !pixmapSettings.outputRect) {
+            return;
+        }
+
         var inputRect = pixmapSettings.inputRect,
             outputRect = pixmapSettings.outputRect,
             inputHeight = inputRect.bottom - inputRect.top,


### PR DESCRIPTION
Asset side cleanups for transition away from always using bounds to define scale factor. see Core CL https://github.com/adobe-photoshop/generator-core/pull/336