### PR TITLE
Vector masks should also force a exact bounds call

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1249,13 +1249,14 @@
         // following conditions hold:
         // 1. The component is either not scaled, or is only scaled by an integral
         //    factor (i.e, 100%, 200%, etc.)
-        // 2. The layer does not have an enabled mask
+        // 2. The layer does not have an enabled pixel mask
         // 3. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
         // 4. The "include-ancestor-masks" config option is NOT set
         // 5. The layer does not have any enabled layer effects
         // 6. Component is not resulting in zero bounds.
         // 7. None of the layerGroup has any complexMask.(Ideally, we should try to handle 
         //    complexMask calculations/corrections in getContentBounds.)
+        // 8. The layer does not have a complex vector mask (we can handle a path with a single component)
         // 9. The layer is not hidden.
         var layer = component.layer,
             layerComp = component.comp,
@@ -1267,12 +1268,16 @@
             settingsPromise,
             resultPromise,
             isInvisible = layer && !layer.visible,
+            hasComplexVectorMask = layer && layer.path &&
+                layer.path.pathComponents && Array.isArray(layer.path.pathComponents) &&
+                (layer.path.pathComponents.length > 1),
             isClipped = layer && layer.clipped,
             hasMask = layer && layer.getTotalMaskBounds(),
             includeAncestorMasks = layer && this._includeAncestorMasks;
         
         if (isInvisible ||
             hasComplexTransform ||
+            hasComplexVectorMask ||
             hasMask ||
             isClipped ||
             includeAncestorMasks ||


### PR DESCRIPTION
fix for issue https://github.com/adobe-photoshop/generator-assets/issues/399