### PR TITLE
use exact bounds for all paths,

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1268,16 +1268,16 @@
             settingsPromise,
             resultPromise,
             isInvisible = layer && !layer.visible,
-            hasComplexVectorMask = layer && layer.path &&
+            hasVectorMask = layer && layer.path &&
                 layer.path.pathComponents && Array.isArray(layer.path.pathComponents) &&
-                (layer.path.pathComponents.length > 1),
+                (layer.path.pathComponents.length >= 1),
             isClipped = layer && layer.clipped,
             hasMask = layer && layer.getTotalMaskBounds(),
             includeAncestorMasks = layer && this._includeAncestorMasks;
         
         if (isInvisible ||
             hasComplexTransform ||
-            hasComplexVectorMask ||
+            hasVectorMask ||
             hasMask ||
             isClipped ||
             includeAncestorMasks ||


### PR DESCRIPTION
 since we cannot trust the bounds we get from the layer to be accurate with respect to the pixmap we get back from PS

in this case we get layer bounds that are ~30x32, while the image returned by PS is 30x34 since the bounds are not pixel aligned. 

This Is a fix for https://github.com/adobe-photoshop/generator-assets/issues/350