### PR TITLE
Suppress 'unhandled property' messages for some known new event props

### DIFF
--- a/lib/dom/document.js
+++ b/lib/dom/document.js
@@ -110,6 +110,12 @@
                 case "placed":
                     this._setPlaced(raw.placed);
                     break;
+                case "profile":
+                case "mode":
+                case "depth":
+                    // Do nothing for these properties
+                    // TODO could profile and/or mode be helpful for embedding color profile?
+                    break;
                 default:
                     this._logger.warn("Unhandled property in raw constructor:", property, raw[property]);
                 }


### PR DESCRIPTION
What it says.  This is to clean up the logs a bit.  I noted a TODO item that these properties could actually be useful in the future.