### PR TITLE
expand the use of approximate bounds for layers

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1247,24 +1247,24 @@
     PixmapRenderer.prototype._getData = function (component) {
         // The exact bounds computation, which is expensive, is skipped if all of the
         // following conditions hold:
-        // 1. The component is either not scaled, or is only scaled by an integral
+        // 1. The layerComp is either not scaled, or is only scaled by an integral
         //    factor (i.e, 100%, 200%, etc.)
-        // 2. The layer does not have an enabled pixel mask
-        // 3. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
-        // 4. The "include-ancestor-masks" config option is NOT set
-        // 5. The layer does not have any enabled layer effects
-        // 6. Component is not resulting in zero bounds.
-        // 7. None of the layerGroup has any complexMask.(Ideally, we should try to handle 
+        // 2. The layer is scaled using a scale factor (i.e. 33%, 50%, 200%, etc).
+        // 3. The layer does not have an enabled pixel mask
+        // 4. The layer is clipped, in which case layer.bounds is the clipped size and not the layer size
+        // 5. The "include-ancestor-masks" config option is NOT set
+        // 6. The layer does not have any enabled layer effects
+        // 7. Component is not resulting in zero bounds.
+        // 8. None of the layerGroup has any complexMask.(Ideally, we should try to handle 
         //    complexMask calculations/corrections in getContentBounds.)
-        // 8. The layer does not have a complex vector mask (we can handle a path with a single component)
-        // 9. The layer does not have non integral bounds.
-        // 10. The layer is not hidden.
+        // 9. The layer does not have a complex vector mask (we can handle a path with a single component)
+        // 10. The layer does not have non integral bounds.
+        // 11. The layer is not hidden.
         var layer = component.layer,
             layerComp = component.comp,
-            hasComplexTransform = (layer || layerComp) &&
-                ((component.hasOwnProperty("scale") && component.scale % 1 !== 0) ||
-                  component.hasOwnProperty("width") ||
-                  component.hasOwnProperty("height")),
+            hasComplexTransform = ((layer || layerComp) &&
+                ((component.hasOwnProperty("width") || component.hasOwnProperty("height")))) ||
+                (layerComp && ((component.hasOwnProperty("scale") && component.scale % 1 !== 0))),
             canvasDimensionsScale = 1,
             settingsPromise,
             resultPromise,


### PR DESCRIPTION
since Photoshop now does our scaling we shouldn't need to carea bout non integer scales.

There is a layer comp test in G-a-a that fails if you remove the test for layer comps, so for now i only did layers. 