### PR TITLE
Pass component onRender

### DIFF
--- a/lib/rendermanager.js
+++ b/lib/rendermanager.js
@@ -220,7 +220,7 @@
         var renderer;
 
         process.nextTick(function () {
-            this.emit("render", ++this._renderedAssetCount, document);
+            this.emit("render", ++this._renderedAssetCount, document, component);
         }.bind(this));
 
         if (component.extension === "svg") {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "dependencies": {
     "fs-extra": {
       "version": "0.16.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "dependencies": {
     "fs-extra": {
       "version": "0.16.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "dependencies": {
     "fs-extra": {
       "version": "0.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
   "generator-core-version": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.3",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
-  "generator-core-version": "^3.7.0",
+  "generator-core-version": "^3.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe-photoshop/generator-assets"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
   "generator-core-version": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
   "generator-core-version": "^3.9.0",


### PR DESCRIPTION
I need to get the details of each generated file specially its name... currently the only way possible to do this is by reading the filesystem after everything has been generated... something along these lines:

```
const generatedAssets = glob.sync(__dirname + '/*-assets/*.*');
```

By emitting  this ```component``` object on ```render``` would be of a great value :)