### PR TITLE
Pass component onRender

### DIFF
--- a/lib/rendermanager.js
+++ b/lib/rendermanager.js
@@ -220,7 +220,7 @@
         var renderer;
 
         process.nextTick(function () {
-            this.emit("render", ++this._renderedAssetCount, document);
+            this.emit("render", ++this._renderedAssetCount, document, component);
         }.bind(this));
 
         if (component.extension === "svg") {


### PR DESCRIPTION
I need to get the details of each generated file specially its name... currently the only way possible to do this is by reading the filesystem after everything has been generated... something along these lines:

```
const generatedAssets = glob.sync(__dirname + '/*-assets/*.*');
```

By emitting  this ```component``` object on ```render``` would be of a great value :)

> Actually i meant to push it to the 2.7.4(5?) as its on npm