### PR TITLE
Delay imageChanged event registration until asset generation is first enabled

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,8 @@ module.exports = function (grunt) {
 
         jshint : {
             options : {
-                jshintrc : ".jshintrc"
+                jshintrc : ".jshintrc",
+                reporterOutput: ""
             },
             js : [
                 "*.js",

--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -21,6 +21,8 @@
  *
  */
 
+/* jshint newcap: false */
+
 (function () {
     "use strict";
 

--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -60,6 +60,10 @@
      * Emits "activeDocumentChanged" event when the currently active document changes
      * with the follwing parameter:
      *      1. @param {?number} ID of the currently active document, or null if there is none
+     *
+     * The DocumentManager initially listens only for lightweight photoshop events to maintain
+     * the list of open documents without listening for the more expensive imageChanged event.
+     * Use the `fullSteam()` method to increase the run level which will begin listening to the imageChanged event.
      * 
      * @constructor
      * @param {Generator} generator
@@ -89,17 +93,21 @@
         this._newOpenDocumentIds = {};
         this._newClosedDocumentIds = {};
 
+        this._listeningToImageChanged = false;
+
         this._initActiveDocumentID();
         this._resetOpenDocumentIDs()
             .then(function () {
                 // make sure that openDocumentsChanged fires once on startup, even
                 // if there are no open documents
-                this._handleOpenDocumentsChange();
+                this._openDocumentsChanged();
             }.bind(this))
             .done();
 
-
-        generator.onPhotoshopEvent("imageChanged", this._handleImageChanged.bind(this));
+        this._handleCurrentDocumentChanged = this._handleCurrentDocumentChanged.bind(this);
+        this._handleClosedDocument = this._handleClosedDocument.bind(this);
+        generator.onPhotoshopEvent("currentDocumentChanged", this._handleCurrentDocumentChanged);
+        generator.onPhotoshopEvent("closedDocument", this._handleClosedDocument);
     }
 
     util.inherits(DocumentManager, EventEmitter);
@@ -203,6 +211,14 @@
      * @type {boolean}
      */
     DocumentManager.prototype._clearCacheOnChange = false;
+
+    /**
+     * True if this document manager is already listening to imageChanged events
+     *
+     * @private
+     * @type {boolean}
+     */
+    DocumentManager.prototype._listeningToImageChanged = false;
 
     /**
      * Asynchronously create a new Document object using the full document
@@ -328,13 +344,13 @@
             getCompSettings:    false
         }).then(function (document) {
             if (document) {
-                this._handleActiveDocumentChange(document.id);
+                this._setActiveDocument(document.id);
             } else {
-                this._handleActiveDocumentChange(null);
+                this._setActiveDocument(null);
             }
         }.bind(this)).fail(function (err) {
             this._logger.warn(err);
-            this._handleActiveDocumentChange(null);
+            this._setActiveDocument(null);
         }.bind(this)).done();
     };
 
@@ -398,12 +414,45 @@
     };
 
     /**
+     * Re-initialize the current document completely and remove the cached version of all other documents so they'll be
+     * fetched next time they're needed
+     *
+     * @private
+     * @return {Promise} resolved when active document is refreshed
+     */
+    DocumentManager.prototype._resetAllDocuments = function () {
+        var docPromise;
+        if (this._activeDocumentId) {
+            docPromise = this._initDocument(this._activeDocumentId).promise;
+        } else {
+            docPromise = Q(true);
+        }
+
+        var openDocumentIds = _intKeys(this._openDocumentIds);
+
+        openDocumentIds.forEach(function (id) {
+            if (id === this._activeDocumentId) {
+                return;
+            }
+
+            if (this._documentDeferreds.hasOwnProperty(id)) {
+                this._documentDeferreds[id].reject();
+                delete this._documentDeferreds[id];
+            }
+
+            this._removeDocument(id);
+        }.bind(this));
+
+        return docPromise;
+    };
+
+    /**
      * Emits an "openDocumentsChanged" changed event that includes the currently
      * open set of document IDs, along with recently opened and closed documentIDs.
      *
      * @private
      */
-    DocumentManager.prototype._handleOpenDocumentsChange = function () {
+    DocumentManager.prototype._openDocumentsChanged = function () {
         if (this._openDocumentsChangeTimer) {
             return;
         }
@@ -435,7 +484,7 @@
         this._openDocumentIds[id] = true;
         this._newOpenDocumentIds[id] = true;
         delete this._newClosedDocumentIds[id];
-        this._handleOpenDocumentsChange();
+        this._openDocumentsChanged();
     };
 
     /**
@@ -446,7 +495,7 @@
      */
     DocumentManager.prototype._removeOpenDocumentID = function (id) {
         if (id === this._activeDocumentId) {
-            this._handleActiveDocumentChange(null);
+            this._setActiveDocument(null);
         }
 
         if (!this._openDocumentIds.hasOwnProperty(id)) {
@@ -456,7 +505,7 @@
         delete this._openDocumentIds[id];
         this._newClosedDocumentIds[id] = true;
         delete this._newOpenDocumentIds[id];
-        this._handleOpenDocumentsChange();
+        this._openDocumentsChanged();
     };
 
     /**
@@ -468,7 +517,7 @@
      * @private
      * @param {?number} id
      */
-    DocumentManager.prototype._handleActiveDocumentChange = function (id) {
+    DocumentManager.prototype._setActiveDocument = function (id) {
         this._activeDocumentId = id;
 
         if (this._activeDocumentChangeTimer) {
@@ -503,7 +552,7 @@
         // Update the active document and the set of open documents
         if (change.active) {
             this._resetOpenDocumentIDs().done();
-            this._handleActiveDocumentChange(id);
+            this._setActiveDocument(id);
         } else if (change.closed) {
             this._removeOpenDocumentID(id);
         } else {
@@ -539,20 +588,85 @@
     };
 
     /**
-     * Asynchonously request an up-to-date Document object for the given document ID.
+     * Handler for Photoshop's currentDocumentChanged event
      *
-     * @param {!number} id The document ID
-     * @return {Promise.<Document>} A promise that resoves with a Document object for the given ID
+     * @private
+     * @param {number} id document ID
      */
-    DocumentManager.prototype.getDocument = function (id) {
-        // We're in the process of updating the document; return that when it's ready
-        if (this._documentDeferreds.hasOwnProperty(id)) {
-            return this._documentDeferreds[id].promise;
+    DocumentManager.prototype._handleCurrentDocumentChanged = function (id) {
+        this._resetOpenDocumentIDs().done();
+
+        // It is not expected that this event will be called without an ID,
+        // but if does we will log an error and fall back on a separate photoshop call to get
+        // the active document (or validate that no document is open) with _initActiveDocumentID
+        if (!Number.isInteger(id)) {
+            this._logger.error("CurrentDocumentChanged event provided invalid document id:", id);
+            this._initActiveDocumentID();
+            return;
         }
 
-        // We have a document and we aren't updating it; return it immediately
-        if (this._documents.hasOwnProperty(id)) {
-            return Q.resolve(this._documents[id]);
+        this._setActiveDocument(id);
+    };
+
+    /**
+     * Handler for Photoshop's closeDocument event
+     *
+     * @private
+     * @param {number} id document ID
+     */
+    DocumentManager.prototype._handleClosedDocument = function (id) {
+        if (!Number.isInteger(id)) {
+            throw new Error("closeDocument event provided invalid document id: " + id);
+        }
+
+        this._removeOpenDocumentID(id);
+    };
+
+    /**
+     * Set this document manager into high gear: Listen for imageChanged events.
+     *
+     * The `imageChanged` event is expensive for photoshop to emit.  The original implementation
+     * of this class was to immediately subscribe to the `imageChanged` event immediately
+     * in the DocumentManager constructor.
+     * By introducing this concept of fullSteam - essentially a higher run level - we match the current PS
+     * behavior.  There is currently no going back.  A future improvement, when supported in Photoshop,
+     * could be to bring the run-level back down to not-full-steam when possible.
+     *
+     * FullSteam mode allows un-subscribing from currentDocumentChanged and closedDocument because
+     * the imageChanged handler can track the open documents.
+     */
+    DocumentManager.prototype.fullSteam = function () {
+        if (!this._listeningToImageChanged) {
+            this._generator.onPhotoshopEvent("imageChanged", this._handleImageChanged.bind(this));
+            this._generator.removePhotoshopEventListener("currentDocumentChanged", this._handleCurrentDocumentChanged);
+            this._generator.removePhotoshopEventListener("closedDocument", this._handleClosedDocument);
+
+            this._listeningToImageChanged = true;
+            this._logger.debug("DocumentManager now listening for imageChanged events");
+
+            return this._resetAllDocuments();
+        }
+    };
+
+    /**
+     * Asynchronously request an up-to-date Document object for the given document ID.
+     *
+     * @param {!number} id The document ID
+     * @param {boolean=} forceRefresh optional.  If true, fetch fresh data from Photoshop
+     * @return {Promise.<Document>} A promise that resolves with a Document object for the given ID
+     */
+    DocumentManager.prototype.getDocument = function (id, forceRefresh) {
+        // Default caching behavior as long as a truthy forceRefresh is not supplied
+        if (!forceRefresh) {
+            // We're in the process of updating the document; return that when it's ready
+            if (this._documentDeferreds.hasOwnProperty(id)) {
+                return this._documentDeferreds[id].promise;
+            }
+
+            // We have a document and we aren't updating it; return it immediately
+            if (this._documents.hasOwnProperty(id)) {
+                return Q.resolve(this._documents[id]);
+            }
         }
 
         // We don't know anything about this document; fetch it from Photoshop
@@ -566,24 +680,25 @@
     /**
      * Get the ID of the currently active document, or null if there isn't one. 
      * 
-     * @return {?number] ID of the currently active document.
+     * @return {?number} ID of the currently active document.
      */
     DocumentManager.prototype.getActiveDocumentID = function () {
         return this._activeDocumentId;
     };
 
     /**
-     * Asynchonously request an up-to-date Document object for the currently
+     * Asynchronously request an up-to-date Document object for the currently
      * active document. 
      *
      * @see DocumentManager.prototype.getDocument
      * @see DocumentManager.prototype.getActiveDocumentID
-     * @return {Promise.<Document>} A promise that resoves with a Document object
+     * @param {boolean=} forceRefresh optional.  If true, fetch fresh data from Photoshop
+     * @return {Promise.<Document>} A promise that resolves with a Document object
      *      for the currently active document, or rejects if there is none.
      */
-    DocumentManager.prototype.getActiveDocument = function () {
+    DocumentManager.prototype.getActiveDocument = function (forceRefresh) {
         if (this._activeDocumentId) {
-            return this.getDocument(this._activeDocumentId);
+            return this.getDocument(this._activeDocumentId, forceRefresh);
         } else {
             return Q.reject();
         }

--- a/main.js
+++ b/main.js
@@ -272,7 +272,14 @@
         exports._assetManagers = _assetManagers;
         exports._layerNameParse = require("./lib/parser").parse;
 
-        _stateManager.on("enabled", _startAssetGeneration);
+        // Upon first enablement, bump the documentManager into full steam level
+        // which listens to the more expensive events.  For more info see: documentManager.fullSteam
+        _stateManager.once("enabled", function (id) {
+            _documentManager.fullSteam().then(function () {
+                _startAssetGeneration(id);
+                _stateManager.on("enabled", _startAssetGeneration);
+            });
+        });
         _stateManager.on("disabled", _pauseAssetGeneration);
         _documentManager.on("openDocumentsChanged", _handleOpenDocumentsChanged);
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "fs-extra": {
       "version": "0.16.5",
-      "from": "fs-extra@>=0.16.3 <0.17.0",
+      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
       "dependencies": {
         "graceful-fs": {
@@ -29,19 +29,19 @@
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -61,7 +61,7 @@
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -75,7 +75,7 @@
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -92,9 +92,9 @@
       }
     },
     "q": {
-      "version": "1.0.1",
-      "from": "q@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+      "version": "1.5.0",
+      "from": "q@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
     },
     "svgobjectmodelgenerator": {
       "version": "0.6.0",
@@ -103,12 +103,12 @@
     },
     "tmp": {
       "version": "0.0.28",
-      "from": "tmp@>=0.0.24 <0.1.0",
+      "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "dependencies": {
         "os-tmpdir": {
           "version": "1.0.1",
-          "from": "os-tmpdir@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "fs-extra": "^0.16.3",
-    "q": "~1.0",
+    "q": "^1.5.0",
     "svgobjectmodelgenerator": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#release-0.6",
     "tmp": "~0.0.24"
   },


### PR DESCRIPTION
It is expensive for Photoshop to emit the `imageChanged` event, so we want to prevent generator registering for it unless absolutely necessary.  Currently, we register for `imageChanged` during construction of a `DocumentManager` regardless of whether or not the user has (ever) enabled any of the open documents.

This PR modifies `DocumentManager` to begin life listening only to two lightweight events; just enough to maintain the set of open documents.  When the plugin first becomes enabled (one or more open documents have been enabled the user) the DocumentManager is placed in to full steam mode; it registers for the `imageChanged` event and uses that (and only that) event to maintain the full document model going forward.  This can not be reversed, which matches the behavior of Photoshop.

A note about the name `fullSteam()`.  My proposal is that the absurdity of this method name helps it stand out as a transient design.  This change is intended to be a narrow fix for a performance problem until a more significant change-of-approach can be planned.

This PR also adds a new parameter to the `getDocument` and `getActiveDocument` methods, allowing the returned document info to (optionally) be forcibly refreshed from photoshop.  This is to allow non-standard clients (ie, node dependencies) to fetch up to date documents ad-hoc without relying on the fullSteam document manager.

Optionally, to improve backward compatibility with plugins which depend on `DocumentManager`, for consideration:
1) Allow DocumentManager to start in legacy mode by default (and force off for supported plugins)
2) getDocument could behave differently in fullSteam mode (never use cache if not in fullsteam) 

Side notes:

1) Changed the name of two private methods within DocumentManager so they would not start with `_handle` since that prefix is used for other methods that directly handle events
2) Added a hack to jshint options as a workaround to what I believe is a node/grunt/jshint incompatibility.
3) Upgraded `Q` to 1.5