### PR TITLE
For full document pixmaps, always use exact bounds

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1279,7 +1279,8 @@
             hasMask = layer && layer.getTotalMaskBounds(),
             includeAncestorMasks = layer && this._includeAncestorMasks;
         
-        if (isInvisible ||
+        if (!layer ||
+            isInvisible ||
             hasComplexTransform ||
             hasComplexVectorMask ||
             nonIntegralBounds ||


### PR DESCRIPTION
This is a bit heavy handed, but I'm submitting for consideration and performance evaluation