### PR TITLE
Support different flavors of layer groups

### DIFF
--- a/lib/dom/layer.js
+++ b/lib/dom/layer.js
@@ -1418,6 +1418,8 @@
 
         switch (rawLayer.type) {
         case "layerSection":
+        case "artboardSection":
+        case "framedGroupSection":
             return new LayerGroup(document, parent, rawLayer);
         case "layer":
             return new Layer(document, parent, rawLayer);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -322,14 +322,18 @@
      * @return {object} the topLevelGroup
      **/
     BaseRenderer.prototype._findTopLevelGroup = function (layer) {
-        var topLevelGroup;
-        if (layer) {
-            if (layer.type === "layerSection") {
-                topLevelGroup = layer;
-            } else if (layer.group) {
-                topLevelGroup = layer.group;
-            }
+        if (!layer) {
+            return;
         }
+
+        var topLevelGroup;
+
+        if (layer.type === "layerSection" || layer.type === "artboardSection" || layer.type === "framedGroupSection") {
+            topLevelGroup = layer;
+        } else if (layer.group) {
+            topLevelGroup = layer.group;
+        }
+
         // note that even layers on the top level have a group, but it isn't a layergroup
         while (topLevelGroup && topLevelGroup.group && topLevelGroup.group.group) {
             topLevelGroup = topLevelGroup.group;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "fs-extra": {
       "version": "0.16.5",
-      "from": "fs-extra@>=0.16.3 <0.17.0",
+      "from": "fs-extra@0.16.5",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
       "dependencies": {
         "graceful-fs": {
@@ -97,9 +97,9 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
     },
     "svgobjectmodelgenerator": {
-      "version": "0.6.0",
-      "from": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#release-0.6",
-      "resolved": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#b8a568dc24daa8c1bf41f83dfa9ec5b007fe46e8"
+      "version": "0.6.1",
+      "from": "git+https://github.com/adobe-photoshop/svgObjectModelGenerator.git#release-0.6",
+      "resolved": "git+https://github.com/adobe-photoshop/svgObjectModelGenerator.git#e454829d17ee84d18aca40798351a3c77e7d4d13"
     },
     "tmp": {
       "version": "0.0.28",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "fs-extra": "^0.16.3",
     "q": "~1.0",
-    "svgobjectmodelgenerator": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#release-0.6",
+    "svgobjectmodelgenerator": "git+https://github.com/adobe-photoshop/svgObjectModelGenerator.git#release-0.6",
     "tmp": "~0.0.24"
   },
   "devDependencies": {


### PR DESCRIPTION
Layer groups may be one of three types, all of which should be treated the same within generator.  Includes an upgrade SVG OMG dependency which contains similar changes.