### PR TITLE
Change behavior of clearCacheOnChange (used by export as) to ignore metaDataOnly changes

### DIFF
--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -517,7 +517,12 @@
         
         // clear and leave if that option was set
         if (this._clearCacheOnChange) {
-            this._removeDocument(id);
+            if (!change.metaDataOnly) {
+                this._logger.debug("handling imageChanged with clearCacheOnChange, removing document from cache");
+                this._removeDocument(id);
+            } else {
+                this._logger.debug("handling imageChanged with clearCacheOnChange, ignoring because metaDataOnly");
+            }
             return;
         }
 


### PR DESCRIPTION
Export As uses generator-assets (as a lib) in "clearCacheOnChange" mode, which just nukes the cached document info each time an `imageChanged` event is received.  This is different from the default behavior of generator-assets (the plugin) which tries to do smarter things with each imageChanged events; keeping the document information in sync.

This PR makes a fairly narrow change to NOT clear the cached document if the change was "metaDataOnly".  This attempts to fix an issue where saving a document (which may take a long time, in the background) can interfere with a "quick export" initiated immediately following a "save".