### PR TITLE
Allow imageChanged events with generatorSettings to clear the document from cache

### DIFF
--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -515,9 +515,11 @@
             return;
         }
         
-        // clear and leave if that option was set
+        // In clearchCacheOnChange mode:
+        // MetaDataOnly should generally not clear the cache. It is noise from PS that can cause concurrency issues
+        // But if generatorSettings is supplied, then always clear the document from cache.  We care about these
         if (this._clearCacheOnChange) {
-            if (!change.metaDataOnly) {
+            if (!change.metaDataOnly || change.generatorSettings) {
                 this._logger.debug("handling imageChanged with clearCacheOnChange, removing document from cache");
                 this._removeDocument(id);
             } else {


### PR DESCRIPTION
This is a follow up to #443 which introduced a new bug that prevents generatorSettings updates from clearing the cached document.  This only affects crema (Export As) which operates in `clearCacheOnChange` mode.

This PR just narrows down the set of imageChanged events which are treated as safe to: metaDataOnly except when generatorSettings are included

This seems fairly rational, I think, that generatorSettings are special cases.