### PR TITLE
flush cache  on metadataonly if selection included

### DIFF
--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -517,9 +517,9 @@
         
         // In clearchCacheOnChange mode:
         // MetaDataOnly should generally not clear the cache. It is noise from PS that can cause concurrency issues
-        // But if generatorSettings is supplied, then always clear the document from cache.  We care about these
+        // But if generatorSettings or selection is supplied, then always clear the cache.  We care about these events.
         if (this._clearCacheOnChange) {
-            if (!change.metaDataOnly || change.generatorSettings) {
+            if (!change.metaDataOnly || change.generatorSettings  || Array.isArray(change.selection)) {
                 this._logger.debug("handling imageChanged with clearCacheOnChange, removing document from cache");
                 this._removeDocument(id);
             } else {


### PR DESCRIPTION
This is similar to the recent PR #444 
Layer selection changes are another class of "metaDataOnly" imageChanged events that needs to flush the document cache (in the case of Export As).