### PR TITLE
Support g-a-a option to honor standard g-a configs during tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -227,14 +227,17 @@
      * 
      * @private
      * @param {object} config
+     * @param {boolean=} keepExisting if true then don't delete previous configs first. default: false
      */
-    function _setConfig(config) {
+    function _setConfig(config, keepExisting) {
         var property;
 
-        // clear out the existing properties
-        for (property in _config) {
-            if (_config.hasOwnProperty(property)) {
-                delete _config[property];
+        // optionally clean out the existing properties first
+        if (!keepExisting) {
+            for (property in _config) {
+                if (_config.hasOwnProperty(property)) {
+                    delete _config[property];
+                }
             }
         }
 


### PR DESCRIPTION
`_setConfig()` is used by `generator-assets-automation`.  This new argument allows the configs to be merged in to the existing set instead first deleting all properties.