### PR TITLE
Provide useFlite parameter to svgomg

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -495,7 +495,8 @@
             cropRect: cropRect,
             artboardBounds: artboardBounds,
             clipToArtboardBounds: clipToArtboardBounds,
-            isArtboard: isArtboard
+            isArtboard: isArtboard,
+            useFlite: this._useFlite
         };
         
         return svgOMG.getGeneratorSVG(this._generator, params, this._logger).then(

--- a/package-lock.json
+++ b/package-lock.json
@@ -6507,7 +6507,7 @@
       "dev": true
     },
     "svgobjectmodelgenerator": {
-      "version": "github:adobe-photoshop/svgObjectModelGenerator#0a6127de3515092db2b8dcd7a11f7f083fb0e16f",
+      "version": "github:adobe-photoshop/svgObjectModelGenerator#af2fbe0da926c0d0cbd3d92694263db9b0aa61fd",
       "requires": {
         "tmp": "0.0.33"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6507,7 +6507,7 @@
       "dev": true
     },
     "svgobjectmodelgenerator": {
-      "version": "git+https://github.com/adobe-photoshop/svgObjectModelGenerator.git#0a6127de3515092db2b8dcd7a11f7f083fb0e16f",
+      "version": "github:adobe-photoshop/svgObjectModelGenerator#0a6127de3515092db2b8dcd7a11f7f083fb0e16f",
       "requires": {
         "tmp": "0.0.33"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "fs-extra": "^5.0.0",
     "q": "~1.0",
-    "svgobjectmodelgenerator": "github:adobe-photoshop/svgObjectModelGenerator#v0.6.2",
+    "svgobjectmodelgenerator": "github:adobe-photoshop/svgObjectModelGenerator#v0.6.3",
     "tmp": "0.0.33"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "fs-extra": "^5.0.0",
     "q": "~1.0",
-    "svgobjectmodelgenerator": "git+https://github.com/adobe-photoshop/svgObjectModelGenerator.git#v0.6.2",
+    "svgobjectmodelgenerator": "github:adobe-photoshop/svgObjectModelGenerator#v0.6.2",
     "tmp": "0.0.33"
   },
   "devDependencies": {


### PR DESCRIPTION
Provide the "useFlite" config property to svgOMG.  The new default in svgOMG will be to use flite, BUT this allows us to turn it off if necessary via the existing generator-assets `use-flite` config property.

TODO:
~[x] update package.json to point to new version of svgomg after this PR is merged: https://github.com/adobe-photoshop/svgObjectModelGenerator/pull/3~