### PR TITLE
Revert "On demand asset generation, do not listen to imageChanged"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,8 +33,7 @@ module.exports = function (grunt) {
 
         jshint : {
             options : {
-                jshintrc : ".jshintrc",
-                reporterOutput: ""
+                jshintrc : ".jshintrc"
             },
             js : [
                 "*.js",

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -38,6 +38,19 @@
     var MAX_PATH_LENGTH = os.platform() === "darwin" ? 255 : 260;
 
     /**
+     * Return the keys for a set as integers.
+     * 
+     * @private
+     * @param {{number: *}} set A set
+     * @return {Array.<number>} The keys of the set as integers
+     */
+    function _intKeys(set) {
+        return Object.keys(set).map(function (key) {
+            return parseInt(key, 10);
+        });
+    }
+
+    /**
      * The asset manager maintains a set of assets for a given document. On
      * initialization, it parses the layers' names into a set of components,
      * requests renderings of each of those components from the render manager,
@@ -64,6 +77,9 @@
         this._renderManager = renderManager;
         this._fileManager = new FileManager(generator, config, logger);
         this._errorManager = new ErrorManager(generator, config, logger, this._fileManager);
+
+        this._handleChange = this._handleChange.bind(this);
+        this._handleCompsChange = this._handleCompsChange.bind(this);
     }
 
     util.inherits(AssetManager, events.EventEmitter);
@@ -306,7 +322,6 @@
         
         var layerIdsWithComponents = [],
             compComponents = [],
-            renderingsRequested = 0,
             comps = this._document._comps,
             docMeta = this._getDocumentMetaData(),
             documentComponents = [],
@@ -317,28 +332,23 @@
         }
         
         layerIdsWithComponents = this._initComponents();
-        renderingsRequested += this._requestRenderForLayers(layerIdsWithComponents);
+        this._requestRenderForLayers(layerIdsWithComponents);
 
         if (comps) {
             comps.forEach(function (comp) {
                 this._addComponentsForComp(comp, this._document, compComponents);
             }.bind(this));
-            renderingsRequested += this._requestRenderForComponents(compComponents);
+            this._requestRenderForComponents(compComponents);
         }
 
         if (documentAssetSettings) {
             documentAssetSettings.forEach(function (settings) {
                 this._addComponentForDocument(settings, this._document, documentComponents);
             }.bind(this));
-            renderingsRequested += this._requestRenderForComponents(documentComponents);
+            this._requestRenderForComponents(documentComponents);
         }
 
         this._errorManager.reportErrors();
-
-        // Special case: if nothing rendered, immediately emit idle event
-        if (renderingsRequested === 0) {
-            this.emit("idle");
-        }
     };
     
     /**
@@ -347,20 +357,17 @@
      * 
      * @private
      * @param {Array} layerIdsWithComponents to be rendered
-     * @return {number} number of renders requested
      */
     AssetManager.prototype._requestRenderForLayers = function (layerIdsWithComponents) {
-        var count = 0;
         layerIdsWithComponents.forEach(function (layerId) {
             var basicComponents = this._componentManager.getBasicComponentsByLayer(layerId);
             basicComponents.forEach(function (component) {
                 var derivedComponents = this._componentManager.getDerivedComponents(component.id);
                 derivedComponents.forEach(function (component) {
-                    count += this._requestRender(component);
+                    this._requestRender(component);
                 }, this);
             }, this);
         }, this);
-        return count;
     };
     
     /**
@@ -368,14 +375,11 @@
      * 
      * @private
      * @param {Array} components
-     * @return {number} number of renders requested
      */
     AssetManager.prototype._requestRenderForComponents = function (components) {
-        var count = 0;
         components.forEach(function (component) {
-            count += this._requestRender(component);
+            this._requestRender(component);
         }, this);
-        return count;
     };
 
     /**
@@ -411,7 +415,6 @@
      * 
      * @private
      * @param {Component} component
-     * @return {number} number of assets at least requested
      */
     AssetManager.prototype._requestRender = function (component) {
         // Crude check for components whose eventual path will be too long
@@ -419,10 +422,12 @@
             var candidatePathLength = this._fileManager.basePath.length + component.assetPath.length + 1;
             if (candidatePathLength >= MAX_PATH_LENGTH) {
                 this._errorManager.addErrorForComponent(component, "Asset path is too long: " + component.assetPath);
-                return 0;
+                return;
             }
         }
-
+        
+        // FIXME: the document and layer might need to be cloned so that they
+        // don't change in the middle of rendering
         var renderPromise = this._renderManager.render(component);
 
         this._renderPromises[component.id] = renderPromise;
@@ -459,8 +464,6 @@
                 }
             }.bind(this))
             .done();
-
-        return 1;
     };
 
     /**
@@ -483,11 +486,217 @@
     };
     
     /**
+     * Cancel outstanding rendering and remove artifacts.
+     * If forgetComponent is set then removed references to compComponents.
+     * 
+     * @private
+     * @param {object} compComponents indexed by component Id
+     * @param {boolean} forgetComponent whether to derefernce the component
+     */
+    AssetManager.prototype._cleanupCompComponents = function (compComponents, forgetComponent) {
+        Object.keys(compComponents).forEach(function (componentId) {
+            var comp = this._componentManager.getComponent(componentId);
+            if (comp) {
+                if (forgetComponent) {
+                    this._componentManager.removeComponent(componentId);
+                }
+                if (this._hasPendingRender(componentId)) {
+                    this._renderManager.cancel(componentId);
+                }
+                this._fileManager.removeFileWithin(comp.assetPath);
+            }
+        }.bind(this));
+    };
+    
+    /**
+     * Handle the document's change events for the comps list.  If comps have changed
+     * reparse those comps and their dependencies into components, and add the 
+     * comp ids into the work set.
+     * 
+     * @private
+     * @param {object} change A change object emitted by the Document instance
+     *      managed by this AssetManager instance.
+     */
+    AssetManager.prototype._handleCompsChange = function (change) {
+        Object.keys(change).forEach(function (compId) {
+            var compComponents = this._componentManager.getComponentsByComp(compId),
+                ccTemp;
+            
+            if (change[compId].type === "removed") {
+                this._errorManager.removeErrors(compId, this._errorManager.LAYER_COMP);
+                this._cleanupCompComponents(compComponents, true);
+                
+            } else {
+                if (change[compId].name) {
+                    this._errorManager.removeErrors(compId, this._errorManager.LAYER_COMP);
+                    this._cleanupCompComponents(compComponents, true);
+                    compComponents = [];
+                    this._addComponentsForComp(change[compId], this._document, compComponents);
+                } else {
+                    ccTemp = [];
+                    Object.keys(compComponents).forEach(function (cmp) {
+                        ccTemp.push(compComponents[cmp]);
+                    });
+                    this._cleanupCompComponents(compComponents, false);
+                    compComponents = ccTemp;
+                }
+                compComponents.forEach(function (component) {
+                    this._requestRender(component);
+                }, this);
+            }
+        }.bind(this));
+    };
+    
+    /**
+     * Handle the document's change events. If the document is closed, finish
+     * processing. If layers are changed, reparse those layers and their
+     * dependencies to into components, and add the layer ids to the work set.
+     * 
+     * @private
+     * @param {object} change A change object emitted by the Document instance
+     *      managed by this AssetManager instance.
+     */
+    AssetManager.prototype._handleChange = function (change) {
+        this._logger.debug("handleChange:", change);
+
+        if (change.file) {
+            if (this._document.saved && !change.file.hasOwnProperty("previousSaved")) {
+                // If the file has been renamed, asset generation will be disabled, so do nothing here
+                return;
+            }
+            this._fileManager.updateBasePath(this._document);
+        }
+
+        if (change.generatorSettings) {
+            this._reset();
+            return;
+        }
+
+        if (change.comps) {
+            this._handleCompsChange(change.comps);
+        }
+        
+        // if the layer was just renamed; then reparse it and figure out if component
+        // settings have changed; if so, add it to the work set; otherwise, just
+        // fire off any relevant rename events;
+
+        if (change.layers) {
+            var changedLayerIds = _intKeys(change.layers);
+
+            // Close the set of changed layers with their dependencies
+            var dependentLayers = changedLayerIds.reduce(function (dependentLayers, id) {
+                var layerChange = change.layers[id],
+                    layer = layerChange.layer,
+                    dependencies = layer.getDependentLayers();
+                
+                return _intKeys(dependencies).reduce(function (dependentLayers, layerId) {
+                    var dependentLayer = dependencies[layerId];
+                    dependentLayers[dependentLayer.id] = dependentLayer;
+                    return dependentLayers;
+                }, dependentLayers);
+            }.bind(this), {});
+
+            // Find all the component specifications for all the changed layers and their dependencies
+            var specificationsByLayer = _intKeys(dependentLayers).reduce(function (specifications, layerId) {
+                var layer = dependentLayers[layerId],
+                    validSpecifications = [];
+
+                this._errorManager.removeErrors(layerId);
+
+                this._componentManager.findAllComponents(layer)
+                    .forEach(function (specification) {
+                        var component = specification.component,
+                            errors = specification.errors;
+
+                        if (component) {
+                            validSpecifications.push(component);
+                        } else if (errors) {
+                            errors.forEach(function (error) {
+                                this._errorManager.addError(layer, error);
+                            }, this);
+                        }
+                    }, this);
+
+                specifications[layer.id] = validSpecifications;
+
+                return specifications;
+            }.bind(this), {});
+
+            // Determine whether or not the changes necessitate a complete reset.
+            // E.g., has a default component changed?
+            var resetRequired = _intKeys(specificationsByLayer).some(function (layerId) {
+                var specifications = specificationsByLayer[layerId];
+
+                return specifications.some(function (specification) {
+                    return specification.hasOwnProperty("default");
+                });
+            }, this);
+
+            if (resetRequired) {
+                this._reset();
+                return;
+            }
+
+            // Compute the set of removed layers;
+            // subtract the removed layers from the set of changed layers above 
+            var removedLayerIds = changedLayerIds.filter(function (layerId) {
+                var layerChange = change.layers[layerId];
+                if (layerChange.type === "removed") {
+                    if (specificationsByLayer.hasOwnProperty(layerId)) {
+                        delete specificationsByLayer[layerId];
+                    }
+                    return true;
+                }
+            }, this);
+
+            // Clear out the removed layer components;
+            // remove the assets from the old components and/or cancel their renders
+            removedLayerIds.forEach(function (layerId) {
+                var componentsToRemove = this._componentManager.getComponentsByLayer(layerId);
+
+                Object.keys(componentsToRemove).forEach(function (componentId) {
+                    this._cleanupDerivedComponents(componentId);
+                    this._componentManager.removeComponent(componentId);
+                }, this);
+
+                this._errorManager.removeErrors(layerId);
+            }, this);
+
+            _intKeys(specificationsByLayer).forEach(function (layerId) {
+                var layer = dependentLayers[layerId],
+                    currentComponents = specificationsByLayer[layerId],
+                    previousComponents = this._componentManager.getComponentsByLayer(layerId);
+
+                Object.keys(previousComponents).forEach(function (componentId) {
+                    this._cleanupDerivedComponents(componentId);
+                    this._componentManager.removeComponent(componentId);
+                }, this);
+
+                currentComponents.forEach(function (component) {
+                    try {
+                        var componentId = this._componentManager.addComponent(layer, component);
+                        this._componentManager.getDerivedComponents(componentId).forEach(function (derivedComponent) {
+                            this._requestRender(derivedComponent);
+                        }, this);
+                    } catch (ex) {
+                        this._errorManager.addError(layer, ex.message);
+                    }
+                }, this);
+            }, this);
+        }
+        
+        if (change.layers || change.comps) {
+            this._errorManager.reportErrors();
+        }
+    };
+
+    /**
      * Start generating assets for the document. All assets for the document will
      * be regenerated initially, and new assets will continually be regenerated
      * as a result of document changes.
      */
     AssetManager.prototype.start = function () {
+        this._document.on("change", this._handleChange);
         this._init();
     };
 
@@ -497,6 +706,7 @@
      * not be updated.
      */
     AssetManager.prototype.stop = function () {
+        this._document.removeListener("change", this._handleChange);
         this._renderManager.cancelAll(this._document.id);
         this._fileManager.cancelAll();
     };

--- a/lib/documentmanager.js
+++ b/lib/documentmanager.js
@@ -21,8 +21,6 @@
  *
  */
 
-/* jshint newcap: false */
-
 (function () {
     "use strict";
 
@@ -33,22 +31,43 @@
 
     var Document = require("./dom/document");
 
-    var ACTIVE_DOCUMENT_CHANGE_HYSTERESIS = 100;
+    var OPEN_DOCUMENTS_CHANGE_HYSTERESIS = 300,
+        ACTIVE_DOCUMENT_CHANGE_HYSTERESIS = 100;
 
     /**
-     * The DocumentManager provides a simple interface maintaining the currently active document,
-     * and provides a method to retrieve an up-to-date Document object from Photoshop.
+     * Return the keys for a set as integers.
+     * 
+     * @private
+     * @param {{number: *}} set A set
+     * @return {Array.<number>} The keys of the set as integers
+     */
+    function _intKeys(set) {
+        return Object.keys(set).map(function (key) {
+            return parseInt(key, 10);
+        });
+    }
 
+    /**
+     * The DocumentManager provides a simple interface for requesting and maintaining
+     * up-to-date Document objects from Photoshop.
+     * 
+     * Emits "openDocumentsChanged" event when the set of open documents changes with
+     * the following parameters:
+     *      1. @param {Array.<number>} IDs for the set of currently open documents
+     *      2. @param {Array.<number>} IDs for the set of recently opened documents
+     *      3. @param {Array.<number>} IDs for the set of recently closed documents
+     * 
      * Emits "activeDocumentChanged" event when the currently active document changes
      * with the follwing parameter:
      *      1. @param {?number} ID of the currently active document, or null if there is none
-     *
+     * 
      * @constructor
      * @param {Generator} generator
      * @param {object} config
      * @param {Logger} logger
      * @param {object*} options, runtime options:
      *                    getDocumentInfoFlags: object, key documented at getDocumentInfo
+     *                    clearCacheOnChange: bool, removes the document from the cache on
      *                          change instead of updating it and sending a change event
      */
     function DocumentManager(generator, config, logger, options) {
@@ -57,16 +76,30 @@
         this._generator = generator;
         this._config = config;
         this._logger = logger;
-
+        
         options = options || {};
         this._getDocumentInfoFlags = options.getDocumentInfoFlags;
+        this._clearCacheOnChange = options.clearCacheOnChange;
+
+        this._documents = {};
+        this._documentDeferreds = {};
+        this._documentChanges = {};
+
+        this._openDocumentIds = {};
+        this._newOpenDocumentIds = {};
+        this._newClosedDocumentIds = {};
 
         this._initActiveDocumentID();
+        this._resetOpenDocumentIDs()
+            .then(function () {
+                // make sure that openDocumentsChanged fires once on startup, even
+                // if there are no open documents
+                this._handleOpenDocumentsChange();
+            }.bind(this))
+            .done();
 
-        this._handleCurrentDocumentChanged = this._handleCurrentDocumentChanged.bind(this);
-        this._handleClosedDocument = this._handleClosedDocument.bind(this);
-        generator.onPhotoshopEvent("currentDocumentChanged", this._handleCurrentDocumentChanged);
-        generator.onPhotoshopEvent("closedDocument", this._handleClosedDocument);
+
+        generator.onPhotoshopEvent("imageChanged", this._handleImageChanged.bind(this));
     }
 
     util.inherits(DocumentManager, EventEmitter);
@@ -80,13 +113,77 @@
     DocumentManager.prototype._generator = null;
 
     /**
+     * A set of per-document-ID up-to-date Document objects.
+     *
+     * @private
+     * @type {{number: Document}}
+     */
+    DocumentManager.prototype._documents = null;
+
+    /**
+     * A set of per-document-ID deferred objects that indicate Document creation in progress.
+     * 
+     * @private
+     * @type {{number: Deferred}}
+     */
+    DocumentManager.prototype._documentDeferreds = null;
+
+    /**
+     * A set of per-document-ID change queues.
+     * 
+     * @private
+     * @type {{number: Array.<object>}}
+     */
+    DocumentManager.prototype._documentChanges = null;
+
+    /**
+     * A set of document IDs for the currently open documents.
+     *
+     * @private
+     * @type {{number: boolean}}
+     */
+    DocumentManager.prototype._openDocumentIds = null;
+
+    /**
+     * A set of recently opened document IDs.
+     *
+     * @private
+     * @type {{number: boolean}}
+     */
+    DocumentManager.prototype._newOpenDocumentIds = null;
+
+    /**
+     * A set of recently closed document IDs.
+     *
+     * @private
+     * @type {{number: boolean}}
+     */
+    DocumentManager.prototype._newClosedDocumentIds = null;
+
+    /**
+     * If non-null, resolves once the set of open document IDs is finished updating
+     *
+     * @private
+     * @type {?Promise}
+     */
+    DocumentManager.prototype._openDocumentIdsUpdatingPromise = null;
+
+    /**
+     * Whether the set of currently open documents needs to be updated.
+     *
+     * @private
+     * @type {boolean}
+     */
+    DocumentManager.prototype._openDocumentIdsStale = false;
+
+    /**
      * The ID of the currently active document, or null if there is none.
      *
      * @private
      * @type {?number}
      */
     DocumentManager.prototype._activeDocumentId = null;
-
+    
     /**
      * Flags to pass into the main call to getDocumentInfo
      *
@@ -94,6 +191,18 @@
      * @type {object}
      */
     DocumentManager.prototype._getDocumentInfoFlags = null;
+    
+    
+    /**
+     * Controls cached document management. The default is to keep the documents in sync
+     * on each change event. You can optional just have the document removed from the 
+     * cache on change so the next call to getDocument() will result in a full call to
+     * getDocumentInfo.
+     *
+     * @private
+     * @type {boolean}
+     */
+    DocumentManager.prototype._clearCacheOnChange = false;
 
     /**
      * Asynchronously create a new Document object using the full document
@@ -110,6 +219,100 @@
     };
     
     /**
+     * Removes the cached instance of the document 
+     * 
+     * @private
+     * @param {!number} id The ID of the Document to remove
+     */
+    DocumentManager.prototype._removeDocument = function (id) {
+        delete this._documents[id];
+        delete this._documentChanges[id];
+    };
+
+    /**
+     * Asynchronously re-initialize the Document object for a given document ID,
+     * discarding the previous Document object and clearing the change queue for
+     * that ID.
+     * 
+     * @private
+     * @param {!number} id The ID of the Document to re-initialize
+     */
+    DocumentManager.prototype._resetDocument = function (id) {
+        this._documentChanges[id] = [];
+        delete this._documents[id];
+
+        this._getEntireDocument(id).done(function (document) {
+            // Dispose of this document reference when the document is closed in Photoshop
+            document.on("closed", function () {
+                this._removeDocument(id);
+                
+                if (this._documentDeferreds.hasOwnProperty(id)) {
+                    this._documentDeferreds[id].reject();
+                    delete this._documentDeferreds[id];
+                }
+            }.bind(this));
+
+            this._documents[id] = document;
+            this._processNextChange(id);
+        }.bind(this), function (err) {
+            this._logger.error("Failed to get document:", err);
+            this._documentDeferreds[id].reject(err);
+        }.bind(this));
+    };
+
+    /**
+     * Asynchronously initialize a Document object for the given document ID.
+     *  
+     * @private
+     * @param {!number} id The ID of the Document to initialize
+     * @return {Promise.<Document>} A promise that resolves with the up-to-date Document
+     */
+    DocumentManager.prototype._initDocument = function (id) {
+        var deferred = Q.defer();
+
+        this._documentDeferreds[id] = deferred;
+        this._resetDocument(id);
+
+        return deferred;
+    };
+
+    /**
+     * For the given document change queue, attempt to apply the next
+     * change from the queue to the appropriate Document. If unable to
+     * apply the change, re-request the entire document. Otherwise, 
+     * continue processing changes from the change queue.
+     * 
+     * @private
+     * @param {!number} id The document ID that indicates the change queue to process
+     */
+    DocumentManager.prototype._processNextChange = function (id) {
+        var document = this._documents[id],
+            changes = this._documentChanges[id],
+            deferred = this._documentDeferreds[id];
+
+        if (!changes || !deferred) {
+            // The document was closed while processing changes
+            return;
+        }
+
+        if (changes.length === 0) {
+            deferred.resolve(document);
+            delete this._documentDeferreds[id];
+            return;
+        }
+
+        var change = changes.shift();
+
+        var success = document._applyChange(change);
+        if (!success) {
+            this._logger.warn("Unable to apply change to document");
+            this._resetDocument(id);
+        } else {
+            this._processNextChange(id);
+        }
+    };
+
+    /**
      * Asynchronously initialize the current active document ID.
      *
      * @private
@@ -125,14 +328,135 @@
             getCompSettings:    false
         }).then(function (document) {
             if (document) {
-                this._setActiveDocument(document.id);
+                this._handleActiveDocumentChange(document.id);
             } else {
-                this._setActiveDocument(null);
+                this._handleActiveDocumentChange(null);
             }
         }.bind(this)).fail(function (err) {
             this._logger.warn(err);
-            this._setActiveDocument(null);
+            this._handleActiveDocumentChange(null);
         }.bind(this)).done();
+    };
+
+    /**
+     * Asynchronously reset the set of open document IDs.
+     * 
+     * Only one instance of this method will execute at a time. Concurrent
+     * executions will result in the method running a second time after the
+     * first instance has finished.
+     * 
+     * @private
+     * @return {!Promise} Resolves once the set of open document IDs has been
+     *      updated.
+     */
+    DocumentManager.prototype._resetOpenDocumentIDs = function () {
+        if (this._openDocumentIdsUpdatingPromise) {
+            this._openDocumentIdsStale = true;
+            return this._openDocumentIdsUpdatingPromise;
+        }
+
+        var promise = this._generator.getOpenDocumentIDs()
+            .then(function (ids) {
+                var originalIds = Object.keys(this._openDocumentIds);
+
+                ids.forEach(function (id) {
+                    if (!this._openDocumentIds.hasOwnProperty(id)) {
+                        this._addOpenDocumentID(id);
+                    }
+                }, this);
+
+                var newIds = ids.reduce(function (ids, id) {
+                    ids[id] = true;
+                    return ids;
+                }, {});
+                
+                originalIds.forEach(function (id) {
+                    if (!newIds.hasOwnProperty(id)) {
+                        this._removeOpenDocumentID(id);
+                    }
+                }, this);
+
+                // In the case that there is an additional pending call to _resetOpenDocumentIDs,
+                // then we will re-call this function synchronously below. In order to
+                // not hit the early return, we need to clear the variable holding a reference to 
+                // the orignal promise. (Or, in the normal case, this is just cleaning up after
+                // ourselves.)
+                this._openDocumentIdsUpdatingPromise = null;
+
+                if (this._openDocumentIdsStale) {
+                    this._openDocumentIdsStale = false;
+
+                    // Returning a new promise in this "then" handler has the effect of not resolving
+                    // the original promise until we're done with the next update.
+                    return this._resetOpenDocumentIDs();
+                }
+            }.bind(this));
+
+        this._openDocumentIdsUpdatingPromise = promise;
+
+        return promise;
+    };
+
+    /**
+     * Emits an "openDocumentsChanged" changed event that includes the currently
+     * open set of document IDs, along with recently opened and closed documentIDs.
+     *
+     * @private
+     */
+    DocumentManager.prototype._handleOpenDocumentsChange = function () {
+        if (this._openDocumentsChangeTimer) {
+            return;
+        }
+
+        this._openDocumentsChangeTimer = setTimeout(function () {
+            var allOpenDocumentIds = _intKeys(this._openDocumentIds),
+                nowOpenDocumentIds = _intKeys(this._newOpenDocumentIds),
+                nowClosedDocumentIds = _intKeys(this._newClosedDocumentIds);
+
+            this._newOpenDocumentIds = {};
+            this._newClosedDocumentIds = {};
+            this._openDocumentsChangeTimer = null;
+
+            this.emit("openDocumentsChanged", allOpenDocumentIds, nowOpenDocumentIds, nowClosedDocumentIds);
+        }.bind(this), OPEN_DOCUMENTS_CHANGE_HYSTERESIS);
+    };
+
+    /**
+     * Add the given document ID from the set of currently open documents.
+     *
+     * @private
+     * @param {number} id
+     */
+    DocumentManager.prototype._addOpenDocumentID = function (id) {
+        if (this._openDocumentIds.hasOwnProperty(id)) {
+            return;
+        }
+
+        this._openDocumentIds[id] = true;
+        this._newOpenDocumentIds[id] = true;
+        delete this._newClosedDocumentIds[id];
+        this._handleOpenDocumentsChange();
+    };
+
+    /**
+     * Remove the given document ID from the set of currently open documents.
+     *
+     * @private
+     * @param {number} id
+     */
+    DocumentManager.prototype._removeOpenDocumentID = function (id) {
+        if (id === this._activeDocumentId) {
+            this._handleActiveDocumentChange(null);
+        }
+
+        if (!this._openDocumentIds.hasOwnProperty(id)) {
+            return;
+        }
+
+        delete this._openDocumentIds[id];
+        this._newClosedDocumentIds[id] = true;
+        delete this._newOpenDocumentIds[id];
+        this._handleOpenDocumentsChange();
     };
 
     /**
@@ -144,7 +468,7 @@
      * @private
      * @param {?number} id
      */
-    DocumentManager.prototype._setActiveDocument = function (id) {
+    DocumentManager.prototype._handleActiveDocumentChange = function (id) {
         this._activeDocumentId = id;
 
         if (this._activeDocumentChangeTimer) {
@@ -159,67 +483,102 @@
     };
 
     /**
-     * Handler for Photoshop's currentDocumentChanged event
-     *
+     * Handler for Photoshop's imageChanged event. Accepts a raw change description object
+     * and, if the change is intended for an extant Document object, updates that object
+     * accordingly. Ignores changes for document IDs for which getDocument has not been
+     * called. The imageChanged events are also used to maintain the current set of open
+     * documents as well as the current active document.
+     * 
      * @private
-     * @param {number} id document ID
+     * @param {object} change A raw change description object
      */
-    DocumentManager.prototype._handleCurrentDocumentChanged = function (id) {
-        // It is not expected that this event will be called without an ID,
-        // but if does we will log an error and fall back on a separate photoshop call to get
-        // the active document (or validate that no document is open) with _initActiveDocumentID
-        if (!Number.isInteger(id)) {
-            this._logger.error("CurrentDocumentChanged event provided invalid document id:", id);
-            this._initActiveDocumentID();
+    DocumentManager.prototype._handleImageChanged = function (change) {
+        if (!change.hasOwnProperty("id")) {
+            this._logger.warn("Received change for unknown document:", change);
             return;
         }
 
-        this._setActiveDocument(id);
-    };
+        var id = change.id;
 
-    /**
-     * Handler for Photoshop's closeDocument event
-     *
-     * @private
-     * @param {number} id document ID
-     */
-    DocumentManager.prototype._handleClosedDocument = function (id) {
-        if (!Number.isInteger(id)) {
-            throw new Error("closeDocument event provided invalid document id: " + id);
+        // Update the active document and the set of open documents
+        if (change.active) {
+            this._resetOpenDocumentIDs().done();
+            this._handleActiveDocumentChange(id);
+        } else if (change.closed) {
+            this._removeOpenDocumentID(id);
+        } else {
+            this._addOpenDocumentID(id);
         }
 
-        this.emit("documentClosed", id);
+        // ignore changes for document IDs until a client calls getDocument
+        if (!this._documentDeferreds.hasOwnProperty(id) && !this._documents.hasOwnProperty(id)) {
+            return;
+        }
+        
+        // clear and leave if that option was set
+        if (this._clearCacheOnChange) {
+            this._removeDocument(id);
+            return;
+        }
+
+        if (!this._documentChanges.hasOwnProperty(id)) {
+            this._documentChanges[id] = [];
+        }
+
+        var changes = this._documentChanges[id],
+            pendingChanges = changes.push(change);
+
+        if (pendingChanges === 1 && !this._documentDeferreds.hasOwnProperty(id)) {
+            if (this._documents.hasOwnProperty(id)) {
+                this._documentDeferreds[id] = Q.defer();
+                this._processNextChange(id);
+            } else {
+                this._initDocument(id);
+            }
+        }
     };
 
     /**
-     * Asynchronously request an up-to-date Document object for the given document ID.
+     * Asynchonously request an up-to-date Document object for the given document ID.
      *
      * @param {!number} id The document ID
-     * @return {Promise.<Document>} A promise that resolves with a Document object for the given ID
+     * @return {Promise.<Document>} A promise that resoves with a Document object for the given ID
      */
     DocumentManager.prototype.getDocument = function (id) {
-        return this._getEntireDocument(id)
-            .catch(function (err) {
-                throw new Error("DocumentManager Failed to getDocument: " + id, err);
-            });
+        // We're in the process of updating the document; return that when it's ready
+        if (this._documentDeferreds.hasOwnProperty(id)) {
+            return this._documentDeferreds[id].promise;
+        }
+
+        // We have a document and we aren't updating it; return it immediately
+        if (this._documents.hasOwnProperty(id)) {
+            return Q.resolve(this._documents[id]);
+        }
+
+        // We don't know anything about this document; fetch it from Photoshop
+        var deferred = this._initDocument(id);
+        deferred.promise.fail(function () {
+            this._removeOpenDocumentID(id);
+        }.bind(this));
+        return deferred.promise;
     };
 
     /**
      * Get the ID of the currently active document, or null if there isn't one. 
      * 
-     * @return {?number} ID of the currently active document.
+     * @return {?number] ID of the currently active document.
      */
     DocumentManager.prototype.getActiveDocumentID = function () {
         return this._activeDocumentId;
     };
 
     /**
-     * Asynchronously request an up-to-date Document object for the currently
+     * Asynchonously request an up-to-date Document object for the currently
      * active document. 
      *
      * @see DocumentManager.prototype.getDocument
      * @see DocumentManager.prototype.getActiveDocumentID
-     * @return {Promise.<Document>} A promise that resolves with a Document object
+     * @return {Promise.<Document>} A promise that resoves with a Document object
      *      for the currently active document, or rejects if there is none.
      */
     DocumentManager.prototype.getActiveDocument = function () {
@@ -228,6 +587,15 @@
         } else {
             return Q.reject();
         }
+    };
+
+    /**
+     * Get the IDs of the currently open documents.
+     * 
+     * @return {Array.<number>} IDs of the currently open documents
+     */
+    DocumentManager.prototype.getOpenDocumentIDs = function () {
+        return _intKeys(this._openDocumentIds);
     };
 
     module.exports = DocumentManager;

--- a/lib/dom/document.js
+++ b/lib/dom/document.js
@@ -25,6 +25,7 @@
     "use strict";
 
     var util = require("util"),
+        assert = require("assert"),
         events = require("events"),
         path = require("path");
 
@@ -300,6 +301,40 @@
         }
     };
 
+    Document.prototype._updateFile = function (rawFile) {
+        var previousFile = this._file,
+            previousName = this.name,
+            previousExtension = this.extension,
+            previousDirectory = this.directory,
+            previousSaved = this.saved;
+
+        if (previousFile !== rawFile) {
+            this._setFile(rawFile);
+
+            var change = {
+                previous: previousFile
+            };
+
+            if (previousName !== this.name) {
+                change.previousName = previousName;
+            }
+
+            if (previousExtension !== this.extension) {
+                change.previousExtension = previousExtension;
+            }
+
+            if (previousDirectory !== this.directory) {
+                change.previousDirectory = previousDirectory;
+            }
+
+            if (previousSaved !== this.saved) {
+                change.previousSaved = previousSaved;
+            }
+
+            return change;
+        }
+    };
+
     Document.prototype._setSelection = function (rawSelection) {
         this._selection = rawSelection.reduce(function (prev, index) {
             var layer = this.layers.findLayerAtIndex(index);
@@ -316,45 +351,32 @@
         }.bind(this), {});
     };
 
+    Document.prototype._updateSelection = function (rawSelection) {
+        var previousSelection = this._selection || {};
+        this._setSelection(rawSelection);
+
+        var previousKeys = Object.keys(previousSelection).sort(),
+            currentKeys = Object.keys(this._selection).sort(),
+            changed = currentKeys.length !== previousKeys.length ||
+                currentKeys.some(function (layerId, index) {
+                    return layerId !== previousKeys[index];
+                });
+
+        if (changed) {
+            return {
+                previous: previousSelection
+            };
+        }
+    };
+
     Document.prototype._setBounds = function (rawBounds) {
         this._bounds = new Bounds(rawBounds);
     };
 
-    Document.prototype._setResolution = function (rawResolution) {
-        var ppi = parseFloat(rawResolution);
-
-        if (isNaN(ppi)) {
-            ppi = 72;
-        }
-
-        this._resolution = ppi;
+    Document.prototype._updateBounds = function (rawBounds) {
+        return this._bounds._applyChange(rawBounds);
     };
-
-    Document.prototype._setGlobalLight = function (rawGlobalLight) {
-        this._globalLight = rawGlobalLight;
-    };
-
-    Document.prototype._setGeneratorSettings = function (rawGeneratorSettings) {
-        this._generatorSettings = rawGeneratorSettings;
-    };
-
-    Document.prototype._setComps = function (raw) {
-        this._comps = raw;
-    };
-
-    Document.prototype._setPlaced = function (raw) {
-        this._placed = raw;
-    };
-
-    Document.prototype._setLayers = function (raw) {
-        var rawLayer = {
-            id: this.id,
-            layers: raw
-        };
-
-        this._layers = createLayer(this, null, rawLayer);
-    };
-
+    
     Document.prototype.getExactBounds = function (layerCompId, maxDimension) {
         var generator = this._generator,
             settings = JSON.parse(JSON.stringify(EXACT_BOUNDS_SETTINGS));
@@ -372,6 +394,495 @@
             .then(function (rawBounds) {
                 return new Bounds(rawBounds);
             }.bind(this));
+    };
+
+    Document.prototype._setResolution = function (rawResolution) {
+        var ppi = parseFloat(rawResolution);
+
+        if (isNaN(ppi)) {
+            ppi = 72;
+        }
+
+        this._resolution = ppi;
+    };
+
+    Document.prototype._updateResolution = function (rawResolution) {
+        var previousResolution = this._resolution;
+        this._setResolution(rawResolution);
+
+        return {
+            previous: previousResolution
+        };
+    };
+
+    Document.prototype._setGlobalLight = function (rawGlobalLight) {
+        this._globalLight = rawGlobalLight;
+    };
+
+    Document.prototype._updateGlobalLight = function (rawGlobalLight) {
+        var previousGlobalLight = this._globalLight;
+        this._setGlobalLight(rawGlobalLight);
+
+        return {
+            previous: previousGlobalLight
+        };
+    };
+
+    Document.prototype._setGeneratorSettings = function (rawGeneratorSettings) {
+        this._generatorSettings = rawGeneratorSettings;
+    };
+
+    Document.prototype._updateGeneratorSettings = function (rawGeneratorSettings) {
+        var previousGeneratorSettings = this._generatorSettings;
+        this._setGeneratorSettings(rawGeneratorSettings);
+
+        return {
+            previous: previousGeneratorSettings,
+            current: this.generatorSettings
+        };
+    };
+
+    Document.prototype._setComps = function (raw) {
+        this._comps = raw;
+    };
+
+    Document.prototype._updateComps = function (raw) {
+        var rawCompChange = {
+                id: this.id,
+                comps: raw
+            },
+            changes = this._getChangedComps(rawCompChange.comps);
+        return changes;
+    };
+    
+    /**
+     * Get a layer comp with the given id
+     * @private
+     * @param {identifier:number} compId
+     * @return layerComp object
+     */
+    Document.prototype._findCompById = function (compId) {
+        var ret;
+        this._comps.some(function (comp) {
+            if (String(comp.id) === String(compId)) {
+                ret = comp;
+            }
+        });
+        return ret;
+    };
+    
+    /**
+     * Traverse the set of rawCompChanges and collect the set of Comp objects referred to 
+     * by the rawCompChanges.  The result is a set of changes.
+     * @private
+     * @param {Array.<object>} rawCompChanges
+     * @param {Object} changes
+     * @return compChangeLookup object
+     */
+    Document.prototype._getChangedComps = function (rawCompChanges, changes) {
+        changes = changes || {};
+
+        rawCompChanges.forEach(function (rawCompChange) {
+            var id = rawCompChange.id,
+                result;
+
+            if (rawCompChange.added) {
+                this._comps.push(rawCompChange);
+                result = rawCompChange;
+                result.type = "added";
+            } else {
+                result = this._findCompById(id);
+                if (!result) {
+                    this._logger.error("Error updating layer comp with id [" + id + "]");
+                    return;
+                }
+                
+                if (rawCompChange.removed) {
+                    result.type = "removed";
+                } else if (rawCompChange.hasOwnProperty("index")) {
+                    result.type = "moved";
+                } else {
+                    result.type = "changed";
+                    result.name = rawCompChange.name;
+                }
+            }
+            changes[id] = result;
+        }.bind(this));
+
+        return changes;
+    };
+    
+
+    Document.prototype._setPlaced = function (raw) {
+        this._placed = raw;
+    };
+
+    Document.prototype._updatePlaced = function (raw) {
+        var previous = this._placed;
+        this._setPlaced(raw);
+
+        return {
+            previous: previous
+        };
+    };
+
+    Document.prototype._setLayers = function (raw) {
+        var rawLayer = {
+            id: this.id,
+            layers: raw
+        };
+
+        this._layers = createLayer(this, null, rawLayer);
+
+        // DEBUG
+        // this._validateLayerChanges(raw);
+    };
+
+    /**
+     * Traverse the set of rawLayerChanges and collect the set of Layer objects in
+     * the Document's current LayerGroup that are referred to by the rawLayerChanges.
+     * The result is a set of change records, each of which contains: an index property
+     * that describes where in the layer tree the layer will eventually reside; a reference
+     * to the Layer object itself, if the rawLayerChange describes an existant layer
+     * (i.e., not an "added" layer); and possibly a "type" property that, if it exists,
+     * can be either "added", "removed" or "moved", which describes the type of structural
+     * change that the layer has undergone.
+     *
+     * @private
+     * @param {Array.<object>} rawLayerChanges
+     * @param {{index: number, type: string=, layer: Layer}=} changes
+     * @return {{index: number, type: string=, layer: Layer=}=}
+     */
+    Document.prototype._getChangedLayers = function (rawLayerChanges, changes) {
+        changes = changes || {};
+
+        rawLayerChanges.forEach(function (rawLayerChange) {
+            var id = rawLayerChange.id,
+                result;
+
+            if (rawLayerChange.hasOwnProperty("layers")) {
+                this._getChangedLayers(rawLayerChange.layers, changes);
+            }
+
+            if (rawLayerChange.added) {
+                result = {
+                    type: "added",
+                    index: rawLayerChange.index
+                };
+            } else {
+                result = this._layers.findLayer(id);
+
+                if (!result) {
+                    if (rawLayerChange.removed) {
+                        // Phantom section/group end layer
+                        return;
+                    } else {
+                        throw new Error("Can't find changed layer:", id);
+                    }
+                }
+
+                if (rawLayerChange.removed) {
+                    result.type = "removed";
+                } else if (rawLayerChange.hasOwnProperty("index")) {
+                    result.type = "moved";
+                }
+            }
+
+            changes[id] = result;
+        }, this);
+
+        return changes;
+    };
+
+    /**
+     * Augment an existing set of change records with additional change records that
+     * correspond to "layersAdjusted" annotations on rawLayerChange descriptions.
+     * 
+     * @private
+     * @param {Array.<object>} rawLayerChanges
+     * @param {{index: number, type: string=, layer: Layer=}} changes
+     */
+    Document.prototype._addChangedLayerRanges = function (rawLayerChanges, changes) {
+        rawLayerChanges.forEach(function (rawLayerChange) {
+            if (rawLayerChange.hasOwnProperty("layers")) {
+                this._addChangedLayerRanges(rawLayerChange.layers, changes);
+            }
+
+            var range;
+            if (rawLayerChange.hasOwnProperty("layersAdjusted") &&
+                rawLayerChange.layersAdjusted.hasOwnProperty("indexRange")) {
+                range = rawLayerChange.layersAdjusted.indexRange;
+            }
+
+            if (rawLayerChange.hasOwnProperty("clipGroup") &&
+                rawLayerChange.clipGroup.hasOwnProperty("indexRange")) {
+                if (range) {
+                    range[0] = Math.min(range[0], rawLayerChange.clipGroup.indexRange[0]);
+                    range[1] = Math.max(range[1], rawLayerChange.clipGroup.indexRange[1]);
+                } else {
+                    range = rawLayerChange.clipGroup.indexRange;
+                }
+            }
+
+            if (range) {
+                var rangeStart = range[0],
+                    rangeEnd = range[1],
+                    layer,
+                    index;
+
+                for (index = rangeStart; index <= rangeEnd; index++) {
+                    layer = this.layers.findLayerAtIndex(index);
+                    if (!layer) {
+                        // The index range likely contains phantom layerSection
+                        // ends, which can safely be ignored
+                        continue;
+                    }
+
+                    if (!changes.hasOwnProperty(layer.id)) {
+                        changes[layer.id] = {
+                            index: index,
+                            layer: layer
+                        };
+                    }
+                }
+            }
+        }, this);
+    };
+
+    /**
+     * For each removed or added layer from a set of layer change records,
+     * remove that layer from the Document's layer group.
+     * 
+     * @param {{index: number, type: string=, layer: Layer=}} changes
+     */
+    Document.prototype._detachMovedLayers = function (changes) {
+        Object.keys(changes)
+            .reduce(function (filteredChanges, id) {
+                var change = changes[id];
+
+                if (change.type === "moved" || change.type === "removed") {
+                    filteredChanges.push(change);
+                }
+                return filteredChanges;
+            }, [])
+            .sort(function (l1, l2) {
+                return l1.index - l2.index;
+            })
+            .forEach(function (change) {
+                // remove the layer from its current position
+                change.layer._detach();
+            });
+    };
+
+    /**
+     * Confirm that the indices referred to in a list of rawLayerChanges are
+     * consistent with the locations of those layers in the Document's current
+     * layer group. This is for debugging purposes only.
+     * 
+     * @param {Array.<object>} rawLayerChanges
+     * @throws {Error} If the layer is not found in the layer group at the index
+     *      mentioned in the rawLayerChange
+     */
+    Document.prototype._validateLayerChanges = function (rawLayerChanges) {
+        rawLayerChanges.forEach(function (rawLayerChange) {
+            if (rawLayerChange.hasOwnProperty("index")) {
+                var index = rawLayerChange.index,
+                    id = rawLayerChange.id,
+                    result = this._layers.findLayer(id);
+
+                if (rawLayerChange.removed) {
+                    assert(!result, "Removed layer " + id + " still exists at index " + result.index);
+                } else {
+                    var message = "Layer " + id + " has index " + result.index + " instead of " + index;
+                    assert.strictEqual(index, result.index, message);
+                }
+
+                if (rawLayerChange.hasOwnProperty("layers")) {
+                    this._validateLayerChanges(rawLayerChange.layers);
+                }
+            }
+        }, this);
+    };
+
+    /**
+     * Given a raw change description for the Document's layer group, update the
+     * Document's layer group and return a set of layer change records, indexed
+     * by the changed layer's id.
+     * 
+     * @param {object} rawChange
+     * @return {{number: {index: number, type: string=, layer: Layer=, changes: object}}}
+     */
+    Document.prototype._updateLayers = function (rawChange) {
+        var rawLayerChange = {
+            id: this.id,
+            layers: rawChange
+        };
+
+        // Find all the existing layers that need to be updated
+        var changes = this._getChangedLayers(rawLayerChange.layers);
+
+        // Add in all the changed layer ranges
+        this._addChangedLayerRanges(rawLayerChange.layers, changes);
+
+        // Remove them from the tree
+        this._detachMovedLayers(changes);
+
+        // Add or re-add new layers to the tree at their new indexes
+        this._layers._applyChange(rawLayerChange, changes);
+
+        // DEBUG
+        // this._validateLayerChanges(rawLayerChange.layers);
+
+        return changes;
+    };
+
+    Document.prototype._applyChange = function (rawChange) {
+        assert.strictEqual(this.id, rawChange.id, "Document ID mismatch");
+        assert.strictEqual(this.version, rawChange.version, "Version mismatch.");
+
+        if (this.timeStamp > rawChange.timeStamp ||
+            (this.timeStamp === rawChange.timeStamp && this.count <= rawChange.count)) {
+            console.warn("Skipping out of order change: this %d@%d; change %d@%d",
+                this.count, this.timeStamp, rawChange.count, rawChange.timeStamp);
+            return true;
+        }
+
+        if (rawChange.hasOwnProperty("changed")) {
+            this.emit("end", "Unknown change");
+            return false;
+        }
+
+        this._count = rawChange.count;
+        this._timeStamp = rawChange.timeStamp;
+
+        var changes = {},
+            property,
+            change;
+
+        for (property in rawChange) {
+            if (rawChange.hasOwnProperty(property)) {
+                try {
+                    switch (property) {
+                    case "file":
+                        change = this._updateFile(rawChange.file);
+                        if (change) {
+                            changes.file = change;
+                        }
+                        break;
+                    case "globalLight":
+                        change = this._updateGlobalLight(rawChange.globalLight);
+                        if (change) {
+                            changes.globalLight = change;
+                        }
+                        break;
+                    case "bounds":
+                        // TODO: Fix this in PS instead. PS does not notify us of the layer bounds changes when the
+                        // document bounds change (from the Image Size dialog, Canvas Size dialog, Crop tool,
+                        // resolution, etc.,). Since all layer bounds likely changed just re-request the whole docinfo.
+                        // https://watsonexp.corp.adobe.com/#bug=3974492
+                        throw new Error("Re-requesting docinfo due to document bounds change.");
+
+                        // Ideally, we would just do this:
+                        // change = this._updateBounds(rawChange.bounds);
+                        // if (change) {
+                        //     changes.bounds = change;
+                        // }
+                        // break;
+                    case "resolution":
+                        //see comment above for "bounds"
+                        throw new Error("Re-requesting docinfo due to document resolution change.");
+                        //change = this._updateResolution(rawChange.resolution);
+                        //if (change) {
+                        //    changes.resolution = change;
+                        //}
+                        //break;
+                    case "selection":
+                        // Resolving the selection depends on the layers; set it in a later pass
+                        break;
+                    case "generatorSettings":
+                        change = this._updateGeneratorSettings(rawChange.generatorSettings);
+                        if (change) {
+                            changes.generatorSettings = change;
+                        }
+                        break;
+                    case "layers":
+                        change = this._updateLayers(rawChange.layers);
+                        if (change) {
+                            changes.layers = change;
+                        }
+                        break;
+                    case "comps":
+                        change = this._updateComps(rawChange.comps);
+                        if (change) {
+                            changes.comps = change;
+                        }
+                        break;
+                    case "placed":
+                        change = this._updatePlaced(rawChange.placed);
+                        if (change) {
+                            changes.placed = change;
+                        }
+                        break;
+                    case "closed":
+                        changes.closed = !!rawChange.closed;
+                        break;
+                    case "active":
+                        changes.active = !!rawChange.active;
+                        break;
+                    case "merged":
+                        changes.merged = !!rawChange.merged;
+                        break;
+                    case "flattened":
+                        changes.flattened = !!rawChange.flattened;
+                        break;
+                    case "metaDataOnly":
+                        changes.metaDataOnly = !!rawChange.metaDataOnly;
+                        break;
+                    case "id":
+                    case "timeStamp":
+                    case "count":
+                    case "version":
+                        // Do nothing for these properties
+                        break;
+                    default:
+                        this._logger.warn("Unhandled property in raw change:", property, rawChange[property]);
+                    }
+                } catch (ex) {
+                    this._logger.error("Error updating property", property, rawChange[property], ex);
+                    this.emit("end", "Failed to apply change", property, rawChange[property], ex);
+                    return false;
+                }
+            }
+        }
+
+        try {
+            if (rawChange.hasOwnProperty("selection")) {
+                change = this._updateSelection(rawChange.selection);
+                if (change) {
+                    changes.selection = change;
+                }
+            }
+        } catch (ex) {
+            this._logger.error("Error updating property", property, rawChange.selection, ex);
+            this.emit("end", "Failed to apply change", property, rawChange.selection, ex);
+            return false;
+        }
+
+        if (Object.keys(changes).length > 0) {
+            var changeName;
+            for (changeName in changes) {
+                if (changes.hasOwnProperty(changeName)) {
+                    this.emit(changeName, changes[changeName], changes.timeStamp, changes.count);
+                }
+            }
+
+            changes.id = rawChange.id;
+            changes.timeStamp = rawChange.timeStamp;
+            changes.count = rawChange.count;
+            this.emit("change", changes);
+        }
+
+        return true;
     };
 
     Document.prototype.toString = function () {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -32,7 +32,7 @@
         // The following constant MUST match the dummy menu ID, which is defined
         // in Presets/Scripts/generate.jsx
         DUMMY_MENU_ID = "generator-assets-dummy-menu",
-
+        DUMMY_MENU_CLICK_TIMEOUT = 3000,
         // Note to third-party plugin developers: This string format ("$$$...") is used for
         // localization of strings that are built in to Photoshop. Third-party plugins should
         // use a regular string (or use their own approach to localization) for menu labels.
@@ -54,8 +54,9 @@
      * @param {Generator} generator
      * @param {object} config
      * @param {Logger} logger
+     * @param {DocumentManager} documentManager
      */
-    function StateManager(generator, config, logger) {
+    function StateManager(generator, config, logger, documentManager) {
         EventEmitter.call(this);
 
         this._generator = generator;
@@ -66,6 +67,10 @@
         this._menuPromise = this._generator.addMenuItem(MENU_ID, MENU_LABEL, false, false)
             .finally(this._processNextMenuOperation.bind(this, false, false));
 
+        documentManager.on("activeDocumentChanged",
+            this._handleActiveDocumentChanged.bind(this));
+        documentManager.on("openDocumentsChanged",
+            this._handleOpenDocumentsChanged.bind(this));
         this._generator.onPhotoshopEvent("generatorMenuChanged",
             this._handleMenuClicked.bind(this));
     }
@@ -107,18 +112,65 @@
     StateManager.prototype._dummyMenuClicked = false;
 
     /**
+     * Handle the openDocumentsChanged event emitted by the DocumentManager.
+     * Updates the internal set of documents for which Generator is enabled.
+     * 
+     * @private
+     * @param {Array.<number>} all The complete set of open document IDs
+     * @param {Array.<number>=} opened The set of newly opened document IDs
+     * @param {Array.<number>=} closed The set of newly closed documentIDs
+     */
+    StateManager.prototype._handleOpenDocumentsChanged = function (all, opened, closed) {
+        var open = opened || all;
+
+        open.forEach(function (id) {
+            this._generator.getDocumentSettingsForPlugin(id, PLUGIN_ID).done(function (settings) {
+                // If we've already explicitly enabled this document as a result of
+                // a dummy menu click then ignore the document's stored settings
+                if (this._enabledDocumentIds.hasOwnProperty(id)) {
+                    return;
+                }
+                
+                var enabled = !!(settings && settings.enabled);
+                this._setInternalState(id, enabled);
+
+                // If the openDocumentsChanged event includes the active document,
+                // but the corresponding activeDocumentChange event fired first then
+                // that handler would have been unable to set the menu state.
+                if (this._activeDocumentId === id) {
+                    this._handleActiveDocumentChanged(id);
+                }
+            }.bind(this));
+        }, this);
+
+        if (closed) {
+            closed.forEach(function (id) {
+                this._setInternalState(id, false);
+            }, this);
+        }
+
+        if (all.length === 0) {
+            this._setMenuState(null, false, false);
+        }
+    };
+
+    /**
      * Handle the activeDocumentChanged event emitted by the DocumentManager.
      * Updates the menu state.
      * 
      * @private
      * @param {?number} id The ID of the new currently active document, or null if
      *      there is none.
-     * @param {boolean} checked If the menu item should be checked
      */
-    StateManager.prototype.setState = function (id, checked) {
-        this._logger.debug("setState", id, checked);
+    StateManager.prototype._handleActiveDocumentChanged = function (id) {
+        this._activeDocumentId = id;
+
         if (id) {
-            this._setMenuState(id, true, checked);
+            if (this._dummyMenuClicked) {
+                this.activate(id);
+            } else {
+                this._setMenuState(id, true, this._enabledDocumentIds.hasOwnProperty(id));
+            }
         } else {
             this._setMenuState(null, false, false);
         }
@@ -140,16 +192,48 @@
             return;
         }
 
-        // TODO can we get rid of DUMMY_MENU_ID? We'll handle it the same way as regular menu anyway.
         if (menu.name === DUMMY_MENU_ID) {
-            this._logger.warn("DUMMY MENU ITEM CLICKED");
-        }
+            // When we receive a dummy menu click, instead of toggling the
+            // generator status for the current document we should force
+            // generator to be enabled. However, we may or may not have
+            // received an activeDocumentChanged event by the time of the
+            // click. If we HAVE received such an event and know the active
+            // document, explicitly activate it as a result of the dummy menu
+            // click. Otherwise, note that we have received a dummy menu click
+            // and wait a few seconds for an activeDocumentChanged event. If
+            // the event arrives, activate that document. Otherwise, clear the
+            // flag and proceed as usual.
+            if (this._activeDocumentId !== null) {
+                this.activate(this._activeDocumentId);
+            } else {
+                this._dummyMenuClicked = true;
 
-        if (menu.name !== MENU_ID && menu.name !== DUMMY_MENU_ID) {
+                setTimeout(function () {
+                    this._dummyMenuClicked = false;
+                }.bind(this), DUMMY_MENU_CLICK_TIMEOUT);
+            }
             return;
         }
 
-        this.emit("menuToggled");
+        // Ignore changes to other menus
+        if (menu.name !== MENU_ID) {
+            return;
+        }
+
+        var activeDocumentId = this._activeDocumentId;
+        if (activeDocumentId === null) {
+            this._logger.warn("Ignoring menu click without a current document.");
+            return;
+        }
+
+        var currentMenuState = this._generator.getMenuState(menu.name),
+            currentChecked = currentMenuState.checked;
+
+        if (currentChecked) {
+            this.deactivate(activeDocumentId);
+        } else {
+            this.activate(activeDocumentId);
+        }
     };
 
     /**
@@ -169,8 +253,16 @@
 
         // If there is a saved next state, handle it now if it's consistent with the current document id
         if (nextMenuState) {
-            if (enabled !== nextMenuState.enabled || checked !== nextMenuState.checked) {
-                this._setMenuState(nextMenuState.id, nextMenuState.enabled, nextMenuState.checked);
+            if (this._activeDocumentId === nextMenuState.id) {
+                if (enabled !== nextMenuState.enabled || checked !== nextMenuState.checked) {
+                    this._setMenuState(nextMenuState.id, nextMenuState.enabled, nextMenuState.checked);
+                }
+            } else {
+                // Something went wrong; reset menu state to that of _activeDocumentId
+                var nextEnabled = this._activeDocumentId !== null,
+                    nextChecked = this._enabledDocumentIds.hasOwnProperty(this._activeDocumentId);
+
+                this._setMenuState(this._activeDocumentId, nextEnabled, nextChecked);
             }
         }
     };
@@ -203,12 +295,49 @@
     };
 
     /**
+     * Record the state of the given document ID (i.e., enabled or disabled) and,
+     * if the state has changed, emit the appropriate state change event.
+     * 
+     * @private
+     * @param {number} id A document's ID
+     * @param {boolean} enabled Whether or not the document is currently enabled
+     */
+    StateManager.prototype._setInternalState = function (id, enabled) {
+        if (this._enabledDocumentIds.hasOwnProperty(id) !== enabled) {
+            var eventName = enabled ? "enabled" : "disabled";
+
+            if (enabled) {
+                this._enabledDocumentIds[id] = true;
+            } else {
+                delete this._enabledDocumentIds[id];
+            }
+
+            this.emit(eventName, id);
+        }
+    };
+
+    /**
+     * Update the document's Generator state.
+     * 
+     * @private
+     * @param {number} id
+     * @param {boolean} enabled
+     */
+    StateManager.prototype._setDocumentState = function (id, enabled) {
+        var settings = { enabled: enabled };
+
+        this._generator.setDocumentSettingsForPlugin(settings, PLUGIN_ID).done();
+        this._setInternalState(id, enabled);
+        this._setMenuState(id, true, enabled);
+    };
+
+    /**
      * Deactivate asset generation for the given document ID.
      * 
      * @param {number} id The ID of the Document to deactivate.
      */
     StateManager.prototype.deactivate = function (id) {
-        this._setMenuState(id, true, false);
+        this._setDocumentState(id, false);
     };
 
     /**
@@ -217,7 +346,7 @@
      * @param {number} id The ID of the Document to activate.
      */
     StateManager.prototype.activate = function (id) {
-        this._setMenuState(id, true, true);
+        this._setDocumentState(id, true);
     };
 
     module.exports = StateManager;

--- a/main.js
+++ b/main.js
@@ -29,6 +29,8 @@
         RenderManager = require("./lib/rendermanager"),
         AssetManager = require("./lib/assetmanager"),
         Headlights = require("./lib/headlights");
+    
+    var PLUGIN_ID = require("./package.json").name;
 
     var _generator,
         _config,
@@ -36,164 +38,168 @@
         _documentManager,
         _stateManager,
         _renderManager,
-        _assetManagers,
         _SONToCSSConverter;
 
+    var _assetManagers = {};
+
+    var _waitingDocuments = {},
+        _canceledDocuments = {};
+
     /**
-     * Update the menu/state if the ID matches the current document.
-     * Changes to the asset generation status of a document may occur when it is not the active document in photoshop
-     *
+     * Disable asset generation for the given Document ID, halting any asset
+     * rending in progress.
+     * 
      * @private
-     * @param {number} id
-     * @param {boolean} checked
+     * @param {!number} id The document ID for which asset generation should be disabled.
      */
-    function _updateMenuIfActiveDoc(id, checked) {
-        if (id === _documentManager.getActiveDocumentID()) {
-            _stateManager.setState(id, checked);
+    function _pauseAssetGeneration(id) {
+        if (_waitingDocuments.hasOwnProperty(id)) {
+            _canceledDocuments[id] = true;
+        } else if (_assetManagers.hasOwnProperty(id)) {
+            _assetManagers[id].stop();
         }
     }
 
     /**
-     * Test if there an active AssetManager for the given document
-     *
+     * Completely stop asset generation for the given Document ID and collect
+     * its AssetManager instance.
+     * 
      * @private
-     * @param {number} id
-     * @return {boolean}
+     * @param {!number} id The document ID for which asset generation should be disabled.
      */
-    function _documentIsGenerating(id) {
-        return _assetManagers.has(id);
+    function _stopAssetGeneration(id) {
+        _pauseAssetGeneration(id);
+
+        if (_assetManagers.hasOwnProperty(id)) {
+            delete _assetManagers[id];
+        }
     }
 
     /**
-     * Start an AssetManager and add it to the local map of managers.
+     * Handler for a the "file" change event fired by Document objects. Disables
+     * asset generation after Save As is performed on an an already-saved file.
+     * 
+     * @private
+     * @param {number} id The ID of the Document that changed
+     * @param {{previous: string=, previousSaved: boolean=}}} change The file
+     *      change event emitted by the Document
+     */
+    function _handleFileChange(id, change) {
+        // If the filename changed but the saved state didn't change, then the file must have been renamed
+        if (change.previous && !change.hasOwnProperty("previousSaved")) {
+            _stopAssetGeneration(id);
+            _stateManager.deactivate(id);
+        }
+    }
+
+    /**
+     * Handler for a the "openDocumentsChanged" event emitted by the DocumentManager.
+     * Registers a generatorSettings change to update the StateManager appropiately
+     * 
+     * @private
+     * @param {Array.<number>} all The complete set of open document IDs
+     * @param {Array.<number>=} opened The set of newly opened document IDs
+     */
+    function _handleOpenDocumentsChanged(all, opened) {
+        var open = opened || all;
+
+        open.forEach(function (id) {
+            _documentManager.getDocument(id).done(function (document) {
+                document.on("generatorSettings", _handleDocGeneratorSettingsChange.bind(undefined, id));
+            }, function (error) {
+                _logger.warning("Error getting document during a document changed event, " +
+                    "document was likely closed.", error);
+            });
+        });
+    }
+
+    /**
+     * Extract generator settings from the "current" or "previous" property of a generatorSettings
+     * change event. If the supplied value is not actually a settings object, returns null.
      *
      * @private
-     * @param {Document} document
+     * @param {object} settings Settings json object.
+     * @return {object} Settings object from generator or null.
      */
-    function _startAssetManager(document) {
-        try {
-            var id = document.id,
-                assetManager = new AssetManager(_generator, _config, _logger, document, _renderManager);
+    function _getChangedSettings(settings) {
+        if (settings && typeof(settings) === "object") {
+            return _generator.extractDocumentSettings({generatorSettings: settings}, PLUGIN_ID);
+        }
+        return null;
+    }
 
-            _assetManagers.set(id, assetManager);
-
-            assetManager.once("idle", function () {
-                _logger.info("Asset generation complete", id);
-                _assetManagers.delete(id);
-                _updateMenuIfActiveDoc(id, false);
-            });
-
-            _logger.info("Starting asset generation, starting asset manager", id);
-            assetManager.start();
-        } catch (err) {
-            _logger.error("Failed to start asset generation", err);
-            _updateMenuIfActiveDoc(id, false);
+    /**
+     * Handler for a the "generatorSettings" change event fired by Document objects. Updates
+     * the state manger based on the current doc setting if the enable settings actually 
+     * changed
+     * 
+     * @private
+     * @param {number} id The ID of the Document that changed
+     * @param {{previous: settings=, current: settings=}}} change The previous and current
+     *      document settings
+     */
+    function _handleDocGeneratorSettingsChange(id, change) {
+        var curSettings = _getChangedSettings(change.current),
+            prevSettings = _getChangedSettings(change.previous),
+            curEnabled = !!(curSettings && curSettings.enabled),
+            prevEnabled = !!(prevSettings && prevSettings.enabled);
+        
+        if (prevEnabled !== curEnabled) {
+            if (curEnabled) {
+                _stateManager.activate(id);
+            } else {
+                _stateManager.deactivate(id);
+            }
         }
     }
 
     /**
      * Enable asset generation for the given Document ID, causing all annotated
      * assets in the given document to be regenerated.
-     *
-     * Update menu state accordingly
-     *
+     * 
+     * @private
      * @param {!number} id The document ID for which asset generation should be enabled.
      */
-    function startAssetGeneration(id) {
-        if (_documentIsGenerating(id)) {
-            throw new Error("Can not start asset generation, already in progress");
-        }
-
-        _updateMenuIfActiveDoc(id, true);
-
-        _logger.info("Starting asset generation, retrieving document", id);
-
-        _documentManager.getDocument(id).done(_startAssetManager, function (err) {
-            _logger.error("Failed to start asset generation, could not retrieve document", err);
-            _updateMenuIfActiveDoc(id, false);
-        });
-    }
-
-    /**
-     * Abort generation of assets for the given document
-     *
-     * @param {!number} id
-     * @param {string=} reason
-     */
-    function stopAssetGeneration(id, reason) {
-        if (_documentIsGenerating(id)) {
-            _logger.info("Stopping asset generation", reason);
-            _updateMenuIfActiveDoc(id, false);
-            _assetManagers.get(id).stop();
-            _assetManagers.delete(id);
-        }
-    }
-
-    /**
-     * For the current document, toggle assert generation
-     *
-     */
-    function toggleAssetGeneration() {
-        var id = _documentManager.getActiveDocumentID();
-
-        if (!id) {
+    function _startAssetGeneration(id) {
+        if (_waitingDocuments.hasOwnProperty(id)) {
             return;
         }
 
-        if (_documentIsGenerating(id)) {
-            _logger.debug("TOGGLE generation, current: TRUE");
-            stopAssetGeneration(id, "menu toggle");
-        } else {
-            _logger.debug("TOGGLE generation, current: FALSE");
-            startAssetGeneration(id);
-        }
+        var documentPromise = _documentManager.getDocument(id);
+        
+        _waitingDocuments[id] = documentPromise;
+
+        documentPromise.done(function (document) {
+            delete _waitingDocuments[id];
+
+            if (_canceledDocuments.hasOwnProperty(id)) {
+                delete _canceledDocuments[id];
+            } else {
+                if (!_assetManagers.hasOwnProperty(id)) {
+                    _assetManagers[id] = new AssetManager(_generator, _config, _logger, document, _renderManager);
+
+                    document.on("closed", _stopAssetGeneration.bind(undefined, id));
+                    document.on("end", _restartAssetGeneration.bind(undefined, id));
+                    document.on("file", _handleFileChange.bind(undefined, id));
+                }
+                _assetManagers[id].start();
+            }
+        });
     }
 
     /**
-     * Initialize the Assets plugin.
+     * Restart asset generation for the given Document ID. This is called when
+     * a Document emits an "end" event, indicating that there was an error
+     * updating its internal state as from Photoshop's change events.
      * 
-     * @param {Generator} generator The Generator instance for this plugin.
-     * @param {object} config Configuration options for this plugin.
-     * @param {Logger} logger The Logger instance for this plugin.
+     * @private
+     * @param {!number} id The document ID for which asset generation should be enabled.
      */
-    function init(generator, config, logger) {
-        _generator = generator;
-        _config = config;
-        _logger = logger;
-
-        _documentManager = new DocumentManager(generator, config, logger);
-        _stateManager = new StateManager(generator, config, logger, _documentManager);
-        _renderManager = new RenderManager(generator, config, logger);
-        _assetManagers = new Map();
-
-        if (!!_config["css-enabled"]) {
-            var SONToCSS = require("./lib/css/sontocss.js");
-            _SONToCSSConverter = new SONToCSS(generator, config, logger, _documentManager);
-        }
-
-        // For automated tests
-        exports.startAssetGeneration = startAssetGeneration;
-        exports._renderManager = _renderManager;
-        exports._stateManager = _stateManager;
-        exports._assetManagers = _assetManagers;
-        exports._layerNameParse = require("./lib/parser").parse;
-
-        _documentManager.on("activeDocumentChanged", function (id) {
-            _logger.debug("Handling activeDocumentChanged", id);
-            _stateManager.setState(id, _documentIsGenerating(id));
-        });
-
-        _documentManager.on("documentClosed", stopAssetGeneration);
-
-        _stateManager.on("menuToggled", toggleAssetGeneration);
-
-        Headlights.init(generator, logger, _stateManager, _renderManager);
+    function _restartAssetGeneration(id) {
+        _stopAssetGeneration(id);
+        _startAssetGeneration(id);
     }
 
-
-    exports.init = init;
-
-    // ######### For automated tests ##############
     /**
      * Get a copy of the plugin's config object. For automated testing only.
      * 
@@ -238,6 +244,45 @@
         }
     }
 
+
+    /**
+     * Initialize the Assets plugin.
+     * 
+     * @param {Generator} generator The Generator instance for this plugin.
+     * @param {object} config Configuration options for this plugin.
+     * @param {Logger} logger The Logger instance for this plugin.
+     */
+    function init(generator, config, logger) {
+        _generator = generator;
+        _config = config;
+        _logger = logger;
+
+        _documentManager = new DocumentManager(generator, config, logger);
+        _stateManager = new StateManager(generator, config, logger, _documentManager);
+        _renderManager = new RenderManager(generator, config, logger);
+
+        if (!!_config["css-enabled"]) {
+            var SONToCSS = require("./lib/css/sontocss.js");
+            _SONToCSSConverter = new SONToCSS(generator, config, logger, _documentManager);
+        }
+
+        // For automated tests
+        exports._renderManager = _renderManager;
+        exports._stateManager = _stateManager;
+        exports._assetManagers = _assetManagers;
+        exports._layerNameParse = require("./lib/parser").parse;
+
+        _stateManager.on("enabled", _startAssetGeneration);
+        _stateManager.on("disabled", _pauseAssetGeneration);
+        _documentManager.on("openDocumentsChanged", _handleOpenDocumentsChanged);
+
+        Headlights.init(generator, logger, _stateManager, _renderManager);
+    }
+
+
+    exports.init = init;
+
+    // For automated tests
     exports._getConfig = _getConfig;
     exports._setConfig = _setConfig;
 }());

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "fs-extra": {
       "version": "0.16.5",
-      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+      "from": "fs-extra@>=0.16.3 <0.17.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
       "dependencies": {
         "graceful-fs": {
@@ -29,19 +29,19 @@
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -61,7 +61,7 @@
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -75,7 +75,7 @@
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -92,9 +92,9 @@
       }
     },
     "q": {
-      "version": "1.5.0",
-      "from": "q@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      "version": "1.0.1",
+      "from": "q@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
     },
     "svgobjectmodelgenerator": {
       "version": "0.6.0",
@@ -103,12 +103,12 @@
     },
     "tmp": {
       "version": "0.0.28",
-      "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+      "from": "tmp@>=0.0.24 <0.1.0",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "dependencies": {
         "os-tmpdir": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+          "from": "os-tmpdir@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assets",
-  "version": "3.0.0-dev",
+  "version": "2.9.0",
   "description": "Asset generation plug-in for Photoshop Generator",
   "main": "main.js",
   "generator-core-version": "^3.10.0",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "fs-extra": "^0.16.3",
-    "q": "^1.5.0",
+    "q": "~1.0",
     "svgobjectmodelgenerator": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#release-0.6",
     "tmp": "~0.0.24"
   },


### PR DESCRIPTION
Reverts adobe-photoshop/generator-assets#437
The development of this "on demand" change to generator-assets' behavior has been set aside for now.  This PR reverts back to version 2.9 so that we can bring the `master` branch up to date with the active development that has been done over the last year in the `2.9` branch.

The on-demand feature work has been moved to a separate branch
https://github.com/adobe-photoshop/generator-assets/commits/feature/on-demand