### PR TITLE
SVG error handling improvements

### DIFF
--- a/lib/dom/document.js
+++ b/lib/dom/document.js
@@ -110,11 +110,13 @@
                 case "placed":
                     this._setPlaced(raw.placed);
                     break;
-                case "profile":
                 case "mode":
+                    this._setMode(raw.mode);
+                    break;
+                case "profile":
                 case "depth":
                     // Do nothing for these properties
-                    // TODO could profile and/or mode be helpful for embedding color profile?
+                    // TODO could profile be helpful for embedding color profile?
                     break;
                 default:
                     this._logger.warn("Unhandled property in raw constructor:", property, raw[property]);
@@ -205,7 +207,12 @@
         "placed": {
             get: function () { return this._placed; },
             set: function () { throw new Error("Cannot set placed"); }
+        },
+        "mode": {
+            get: function () { return this._mode; },
+            set: function () { throw new Error("Cannot set mode"); }
         }
+
     });
 
     /**
@@ -283,6 +290,12 @@
      * @type {{number, Object}}
      */
     Document.prototype._placed = null;
+
+    /**
+     * @type {{number, string}}
+     */
+    Document.prototype._mode = null;
+
 
     /**
      * @type {{number, Object}}
@@ -520,6 +533,19 @@
     Document.prototype._updatePlaced = function (raw) {
         var previous = this._placed;
         this._setPlaced(raw);
+
+        return {
+            previous: previous
+        };
+    };
+
+    Document.prototype._setMode = function (raw) {
+        this._mode = raw;
+    };
+
+    Document.prototype._updateMode = function (raw) {
+        var previous = this._mode;
+        this._setMode(raw);
 
         return {
             previous: previous
@@ -823,6 +849,12 @@
                             changes.placed = change;
                         }
                         break;
+                    case "mode":
+                        change = this._updateMode(rawChange.mode);
+                        if (change) {
+                            changes.mode = change;
+                        }
+                        break;
                     case "closed":
                         changes.closed = !!rawChange.closed;
                         break;
@@ -906,7 +938,8 @@
             "generatorSettings",
             "layers",
             "comps",
-            "placed"
+            "placed",
+            "mode"
         ]);
 
         // Layers are nested in an extra LayerGroup for the document, so bring them up one level.

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -539,6 +539,8 @@
             sourceObject = layer || layerComp || document;
 
         if (this._useSVGOMG) {
+            var svgOMGPromise;
+
             if (!sourceObject) {
                 return Q.reject(new Error("No source object specified in component."));
             }
@@ -570,15 +572,20 @@
                         settings.isArtboard = !!layer.artboard;
                     }
                 }
-                return this._getSVGOMG(layer.document.id, layer.id, settings);
+                svgOMGPromise = this._getSVGOMG(layer.document.id, layer.id, settings);
             } else /* if layerComp or document */ {
                 settings.constrainToDocBounds = this._clipAllImagesToDocumentBounds;
                 settings.clipToArtboardBounds = this._clipAllImagesToArtboardBounds;
                 if (layerComp) {
                     settings.compId = layerComp.id;
                 }
-                return this._getSVGOMG(this._document.id, "all", settings);
+                svgOMGPromise = this._getSVGOMG(this._document.id, "all", settings);
             }
+
+            return svgOMGPromise.catch(function(e) {
+                e.svgNotSupported = true;
+                throw e;
+            });
         } else {
             if (layer) {
                 return this._generator.getSVG(layer.document.id, layer.id, settings).then(function (result) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6508,7 +6508,7 @@
       "dev": true
     },
     "svgobjectmodelgenerator": {
-      "version": "github:adobe-photoshop/svgObjectModelGenerator#61e9029781912e4dc2a6d852965da3d08be6ee9a",
+      "version": "github:adobe-photoshop/svgObjectModelGenerator#7ff99176c447ed60a7f5db4b1dd4e21b4454704a",
       "requires": {
         "tmp": "0.0.33"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "fs-extra": "^5.0.0",
     "q": "~1.0",
-    "svgobjectmodelgenerator": "github:adobe-photoshop/svgObjectModelGenerator#v0.6.4",
+    "svgobjectmodelgenerator": "github:adobe-photoshop/svgObjectModelGenerator#v0.6.5",
     "tmp": "0.0.33"
   },
   "devDependencies": {


### PR DESCRIPTION
-Add `mode` to the DOM.  Export As needs this to determine SVG compatibility (non-RGB documents)
-Use SVGOMG 0.6.5 which handles more gracefully the situation when the document can not be "normalized" for SVG extraction
-Return a special error property when SVG renderer throws