### PR TITLE
Handle rejection of getDocumentSettingsForPlugin in statemanager to avoid 'quick close' race case

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -124,23 +124,30 @@
         var open = opened || all;
 
         open.forEach(function (id) {
-            this._generator.getDocumentSettingsForPlugin(id, PLUGIN_ID).done(function (settings) {
-                // If we've already explicitly enabled this document as a result of
-                // a dummy menu click then ignore the document's stored settings
-                if (this._enabledDocumentIds.hasOwnProperty(id)) {
-                    return;
-                }
-                
-                var enabled = !!(settings && settings.enabled);
-                this._setInternalState(id, enabled);
+            this._generator.getDocumentSettingsForPlugin(id, PLUGIN_ID)
+                .catch(function () {
+                    // A rejection may indicate the document was opened and
+                    // then immeidately closed.  Ignore it by returning null.
+                    this._logger.warn("Ignoring document because no settings were returned");
+                    return null;
+                }.bind(this))
+                .done(function (settings) {
+                    // If we've already explicitly enabled this document as a result of
+                    // a dummy menu click then ignore the document's stored settings
+                    if (this._enabledDocumentIds.hasOwnProperty(id)) {
+                        return;
+                    }
 
-                // If the openDocumentsChanged event includes the active document,
-                // but the corresponding activeDocumentChange event fired first then
-                // that handler would have been unable to set the menu state.
-                if (this._activeDocumentId === id) {
-                    this._handleActiveDocumentChanged(id);
-                }
-            }.bind(this));
+                    var enabled = !!(settings && settings.enabled);
+                    this._setInternalState(id, enabled);
+
+                    // If the openDocumentsChanged event includes the active document,
+                    // but the corresponding activeDocumentChange event fired first then
+                    // that handler would have been unable to set the menu state.
+                    if (this._activeDocumentId === id) {
+                        this._handleActiveDocumentChanged(id);
+                    }
+                }.bind(this));
         }, this);
 
         if (closed) {


### PR DESCRIPTION
Added a catch to the `generator.getDocumentSettingsForPlugin` promise which will reject if the document has been closed.  This happens (at least) when a document is opened and then quickly closed.