### PR TITLE
If getDocumentInfo fails, write error but don't crash generator

### DIFF
--- a/main.js
+++ b/main.js
@@ -186,6 +186,9 @@
                 }
                 _assetManagers[id].start();
             }
+        }, function (err) {
+            delete _waitingDocuments[id];
+            _logger.error("Failed to start asset generation for document", id, err);
         });
     }
 


### PR DESCRIPTION
Unhandled rejections in `Q`'s `.done()` method are thrown up and out, and that crashes generator.  We have a number of situations where `getDocumentInfo` fails due to a photoshop error.  This PR handles these situations more gracefully.  The document is ignored, and errors are written to generator's logs.